### PR TITLE
Fix bug in FileStorage.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hap"
-version = "0.1.0-pre.4"
+version = "0.1.0-pre.5"
 authors = ["Elias Wilken <elias@wlkn.io>"]
 edition = "2018"
 description = "Rust implementation of the Apple HomeKit Accessory Protocol (HAP)"

--- a/codegen/Cargo.toml
+++ b/codegen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hap-codegen"
-version = "0.1.0-pre.4"
+version = "0.1.0-pre.5"
 authors = ["Elias Wilken <elias@wlkn.io>"]
 edition = "2018"
 description = "Rust implementation of the Apple HomeKit Accessory Protocol (HAP)"

--- a/src/transport/bonjour.rs
+++ b/src/transport/bonjour.rs
@@ -1,14 +1,14 @@
 use serde::{Deserialize, Serialize};
 
 /// Bonjour Feature Flag.
-#[derive(Debug, Copy, Clone, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub enum BonjourFeatureFlag {
     Zero = 0,
     MfiCompliant = 1,
 }
 
 /// Bonjour Status Flag.
-#[derive(Debug, Copy, Clone, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub enum BonjourStatusFlag {
     Zero = 0,
     NotPaired = 1,


### PR DESCRIPTION
FileStorage was opening files for writing without turning on truncate, so if the new contents were smaller, we'd leave some of the old file behind, making it invalid JSON.

This PR fixes that, and adds a test.

Closes #35.