### PR TITLE
Fix talking to multiple clients at once.

### DIFF
--- a/src/transport/http/server.rs
+++ b/src/transport/http/server.rs
@@ -257,8 +257,8 @@ impl Server {
                 //     }),
                 // )?;
 
-                futures::join!(
-                    encrypted_stream.map_err(|e| error!("{:?}", e)).map(|_| ()),
+                tokio::spawn(encrypted_stream.map_err(|e| error!("{:?}", e)).map(|_| ()));
+                tokio::spawn(
                     http.serve_connection(stream_wrapper, api)
                         .map_err(|e| error!("{:?}", e))
                         .map(|_| ()),


### PR DESCRIPTION
Closes #37.

This does two things:

- First, when we receive a new connection, we spawn off tasks to handle it, instead of doing it on the task accepting the connections. This allows us to talk to multiple clients at once, which is both required by the spec ("HAP accessory servers must support eight simultaneous TCP connections", page 52) and necessary for HAP to work correctly on networks with many Apple devices.
- Moving things onto separate tasks caused some issues with making sure the EncryptedStream gets woken when necessary. I changed two `try_read` calls to use `poll_read` (which takes a context and ensures it gets woken), which fixed that.