### PR TITLE
Use macaddr rather than eui48 and bump dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ bytes = "1.0"
 chacha20poly1305 = "0.8"
 ed25519-dalek = { version = "1.0", features = ["std", "serde"] }
 erased-serde = "0.3"
-eui48 = { version = "1.0", features = ["serde"] }
+macaddr = { version = "1.0.1", features = ["serde"] }
 futures = "0.3"
 get_if_addrs = "0.5"
 hkdf = "0.11"

--- a/codegen/src/main.rs
+++ b/codegen/src/main.rs
@@ -1274,7 +1274,7 @@ async fn main() -> Result<()> {
             let config = Config {
                 pin: Pin::new([1, 1, 1, 2, 2, 3, 3, 3])?,
                 name: \"Acme {{service.DefaultDescription}}\".into(),
-                device_id: MacAddress::new([10, 20, 30, 40, 50, 60]),
+                device_id: MacAddress::from([10, 20, 30, 40, 50, 60]),
                 category: {{category service.DefaultDescription}},
                 ..Default::default()
             };

--- a/examples/adding_accessories_dynamically.rs
+++ b/examples/adding_accessories_dynamically.rs
@@ -33,7 +33,7 @@ async fn main() -> Result<()> {
             let config = Config {
                 pin: Pin::new([1, 1, 1, 2, 2, 3, 3, 3])?,
                 name: "Acme Bridge".into(),
-                device_id: MacAddress::new([10, 20, 30, 40, 50, 60]),
+                device_id: MacAddress::from([10, 20, 30, 40, 50, 60]),
                 category: AccessoryCategory::Bridge,
                 ..Default::default()
             };

--- a/examples/air_purifier.rs
+++ b/examples/air_purifier.rs
@@ -1,7 +1,7 @@
 use tokio;
 
 use hap::{
-    accessory::{AccessoryCategory, AccessoryInformation, air_purifier::AirPurifierAccessory},
+    accessory::{air_purifier::AirPurifierAccessory, AccessoryCategory, AccessoryInformation},
     server::{IpServer, Server},
     storage::{FileStorage, Storage},
     Config,

--- a/examples/air_purifier.rs
+++ b/examples/air_purifier.rs
@@ -1,7 +1,7 @@
 use tokio;
 
 use hap::{
-    accessory::{air_purifier::AirPurifierAccessory, AccessoryCategory, AccessoryInformation},
+    accessory::{AccessoryCategory, AccessoryInformation, air_purifier::AirPurifierAccessory},
     server::{IpServer, Server},
     storage::{FileStorage, Storage},
     Config,
@@ -29,7 +29,7 @@ async fn main() -> Result<()> {
             let config = Config {
                 pin: Pin::new([1, 1, 1, 2, 2, 3, 3, 3])?,
                 name: "Acme Air Purifier".into(),
-                device_id: MacAddress::new([10, 20, 30, 40, 50, 60]),
+                device_id: MacAddress::from([10, 20, 30, 40, 50, 60]),
                 category: AccessoryCategory::AirPurifier,
                 ..Default::default()
             };

--- a/examples/air_quality_sensor.rs
+++ b/examples/air_quality_sensor.rs
@@ -1,7 +1,7 @@
 use tokio;
 
 use hap::{
-    accessory::{air_quality_sensor::AirQualitySensorAccessory, AccessoryCategory, AccessoryInformation},
+    accessory::{AccessoryCategory, AccessoryInformation, air_quality_sensor::AirQualitySensorAccessory},
     server::{IpServer, Server},
     storage::{FileStorage, Storage},
     Config,
@@ -29,7 +29,7 @@ async fn main() -> Result<()> {
             let config = Config {
                 pin: Pin::new([1, 1, 1, 2, 2, 3, 3, 3])?,
                 name: "Acme Air Quality Sensor".into(),
-                device_id: MacAddress::new([10, 20, 30, 40, 50, 60]),
+                device_id: MacAddress::from([10, 20, 30, 40, 50, 60]),
                 category: AccessoryCategory::Sensor,
                 ..Default::default()
             };

--- a/examples/air_quality_sensor.rs
+++ b/examples/air_quality_sensor.rs
@@ -1,7 +1,7 @@
 use tokio;
 
 use hap::{
-    accessory::{AccessoryCategory, AccessoryInformation, air_quality_sensor::AirQualitySensorAccessory},
+    accessory::{air_quality_sensor::AirQualitySensorAccessory, AccessoryCategory, AccessoryInformation},
     server::{IpServer, Server},
     storage::{FileStorage, Storage},
     Config,

--- a/examples/async_callbacks.rs
+++ b/examples/async_callbacks.rs
@@ -49,7 +49,7 @@ async fn main() -> Result<()> {
             let config = Config {
                 pin: Pin::new([1, 1, 1, 2, 2, 3, 3, 3])?,
                 name: "Acme Lightbulb".into(),
-                device_id: MacAddress::new([10, 20, 30, 40, 50, 60]),
+                device_id: MacAddress::from([10, 20, 30, 40, 50, 60]),
                 category: AccessoryCategory::Lightbulb,
                 ..Default::default()
             };

--- a/examples/bridged_accessories.rs
+++ b/examples/bridged_accessories.rs
@@ -73,7 +73,7 @@ async fn main() -> Result<()> {
             let config = Config {
                 pin: Pin::new([1, 1, 1, 2, 2, 3, 3, 3])?,
                 name: "Acme Bridge".into(),
-                device_id: MacAddress::new([10, 20, 30, 40, 50, 60]),
+                device_id: MacAddress::from([10, 20, 30, 40, 50, 60]),
                 category: AccessoryCategory::Bridge,
                 ..Default::default()
             };

--- a/examples/callbacks.rs
+++ b/examples/callbacks.rs
@@ -42,7 +42,7 @@ async fn main() -> Result<()> {
             let config = Config {
                 pin: Pin::new([1, 1, 1, 2, 2, 3, 3, 3])?,
                 name: "Acme Lightbulb".into(),
-                device_id: MacAddress::new([10, 20, 30, 40, 50, 60]),
+                device_id: MacAddress::from([10, 20, 30, 40, 50, 60]),
                 category: AccessoryCategory::Lightbulb,
                 ..Default::default()
             };

--- a/examples/carbon_dioxide_sensor.rs
+++ b/examples/carbon_dioxide_sensor.rs
@@ -1,7 +1,7 @@
 use tokio;
 
 use hap::{
-    accessory::{AccessoryCategory, AccessoryInformation, carbon_dioxide_sensor::CarbonDioxideSensorAccessory},
+    accessory::{carbon_dioxide_sensor::CarbonDioxideSensorAccessory, AccessoryCategory, AccessoryInformation},
     server::{IpServer, Server},
     storage::{FileStorage, Storage},
     Config,

--- a/examples/carbon_dioxide_sensor.rs
+++ b/examples/carbon_dioxide_sensor.rs
@@ -1,7 +1,7 @@
 use tokio;
 
 use hap::{
-    accessory::{carbon_dioxide_sensor::CarbonDioxideSensorAccessory, AccessoryCategory, AccessoryInformation},
+    accessory::{AccessoryCategory, AccessoryInformation, carbon_dioxide_sensor::CarbonDioxideSensorAccessory},
     server::{IpServer, Server},
     storage::{FileStorage, Storage},
     Config,
@@ -29,7 +29,7 @@ async fn main() -> Result<()> {
             let config = Config {
                 pin: Pin::new([1, 1, 1, 2, 2, 3, 3, 3])?,
                 name: "Acme Carbon dioxide Sensor".into(),
-                device_id: MacAddress::new([10, 20, 30, 40, 50, 60]),
+                device_id: MacAddress::from([10, 20, 30, 40, 50, 60]),
                 category: AccessoryCategory::Sensor,
                 ..Default::default()
             };

--- a/examples/carbon_monoxide_sensor.rs
+++ b/examples/carbon_monoxide_sensor.rs
@@ -1,7 +1,7 @@
 use tokio;
 
 use hap::{
-    accessory::{AccessoryCategory, AccessoryInformation, carbon_monoxide_sensor::CarbonMonoxideSensorAccessory},
+    accessory::{carbon_monoxide_sensor::CarbonMonoxideSensorAccessory, AccessoryCategory, AccessoryInformation},
     server::{IpServer, Server},
     storage::{FileStorage, Storage},
     Config,

--- a/examples/carbon_monoxide_sensor.rs
+++ b/examples/carbon_monoxide_sensor.rs
@@ -1,7 +1,7 @@
 use tokio;
 
 use hap::{
-    accessory::{carbon_monoxide_sensor::CarbonMonoxideSensorAccessory, AccessoryCategory, AccessoryInformation},
+    accessory::{AccessoryCategory, AccessoryInformation, carbon_monoxide_sensor::CarbonMonoxideSensorAccessory},
     server::{IpServer, Server},
     storage::{FileStorage, Storage},
     Config,
@@ -29,7 +29,7 @@ async fn main() -> Result<()> {
             let config = Config {
                 pin: Pin::new([1, 1, 1, 2, 2, 3, 3, 3])?,
                 name: "Acme Carbon monoxide Sensor".into(),
-                device_id: MacAddress::new([10, 20, 30, 40, 50, 60]),
+                device_id: MacAddress::from([10, 20, 30, 40, 50, 60]),
                 category: AccessoryCategory::Sensor,
                 ..Default::default()
             };

--- a/examples/contact_sensor.rs
+++ b/examples/contact_sensor.rs
@@ -1,7 +1,7 @@
 use tokio;
 
 use hap::{
-    accessory::{contact_sensor::ContactSensorAccessory, AccessoryCategory, AccessoryInformation},
+    accessory::{AccessoryCategory, AccessoryInformation, contact_sensor::ContactSensorAccessory},
     server::{IpServer, Server},
     storage::{FileStorage, Storage},
     Config,
@@ -29,7 +29,7 @@ async fn main() -> Result<()> {
             let config = Config {
                 pin: Pin::new([1, 1, 1, 2, 2, 3, 3, 3])?,
                 name: "Acme Contact Sensor".into(),
-                device_id: MacAddress::new([10, 20, 30, 40, 50, 60]),
+                device_id: MacAddress::from([10, 20, 30, 40, 50, 60]),
                 category: AccessoryCategory::Sensor,
                 ..Default::default()
             };

--- a/examples/contact_sensor.rs
+++ b/examples/contact_sensor.rs
@@ -1,7 +1,7 @@
 use tokio;
 
 use hap::{
-    accessory::{AccessoryCategory, AccessoryInformation, contact_sensor::ContactSensorAccessory},
+    accessory::{contact_sensor::ContactSensorAccessory, AccessoryCategory, AccessoryInformation},
     server::{IpServer, Server},
     storage::{FileStorage, Storage},
     Config,

--- a/examples/cooler.rs
+++ b/examples/cooler.rs
@@ -29,7 +29,7 @@ async fn main() -> Result<()> {
             let config = Config {
                 pin: Pin::new([1, 1, 1, 2, 2, 3, 3, 3])?,
                 name: "Acme Cooler".into(),
-                device_id: MacAddress::new([10, 20, 30, 40, 50, 60]),
+                device_id: MacAddress::from([10, 20, 30, 40, 50, 60]),
                 category: AccessoryCategory::AirConditioner,
                 ..Default::default()
             };

--- a/examples/custom_characteristics_services_accessories.rs
+++ b/examples/custom_characteristics_services_accessories.rs
@@ -240,7 +240,7 @@ async fn main() -> Result<()> {
             let config = Config {
                 pin: Pin::new([1, 1, 1, 2, 2, 3, 3, 3])?,
                 name: "Acme Foo".into(),
-                device_id: MacAddress::new([10, 20, 30, 40, 50, 60]),
+                device_id: MacAddress::from([10, 20, 30, 40, 50, 60]),
                 category: AccessoryCategory::Other,
                 ..Default::default()
             };

--- a/examples/custom_multi_sensor.rs
+++ b/examples/custom_multi_sensor.rs
@@ -111,7 +111,7 @@ async fn main() -> Result<()> {
             let config = Config {
                 pin: Pin::new([1, 1, 1, 2, 2, 3, 3, 3])?,
                 name: "Acme Temperature & Humidity Sensor".into(),
-                device_id: MacAddress::new([10, 20, 30, 40, 50, 60]),
+                device_id: MacAddress::from([10, 20, 30, 40, 50, 60]),
                 category: AccessoryCategory::Sensor,
                 ..Default::default()
             };

--- a/examples/dehumidifier.rs
+++ b/examples/dehumidifier.rs
@@ -29,7 +29,7 @@ async fn main() -> Result<()> {
             let config = Config {
                 pin: Pin::new([1, 1, 1, 2, 2, 3, 3, 3])?,
                 name: "Acme Dehumidifier".into(),
-                device_id: MacAddress::new([10, 20, 30, 40, 50, 60]),
+                device_id: MacAddress::from([10, 20, 30, 40, 50, 60]),
                 category: AccessoryCategory::AirDehumidifier,
                 ..Default::default()
             };

--- a/examples/door.rs
+++ b/examples/door.rs
@@ -1,7 +1,7 @@
 use tokio;
 
 use hap::{
-    accessory::{AccessoryCategory, AccessoryInformation, door::DoorAccessory},
+    accessory::{door::DoorAccessory, AccessoryCategory, AccessoryInformation},
     server::{IpServer, Server},
     storage::{FileStorage, Storage},
     Config,

--- a/examples/door.rs
+++ b/examples/door.rs
@@ -1,7 +1,7 @@
 use tokio;
 
 use hap::{
-    accessory::{door::DoorAccessory, AccessoryCategory, AccessoryInformation},
+    accessory::{AccessoryCategory, AccessoryInformation, door::DoorAccessory},
     server::{IpServer, Server},
     storage::{FileStorage, Storage},
     Config,
@@ -29,7 +29,7 @@ async fn main() -> Result<()> {
             let config = Config {
                 pin: Pin::new([1, 1, 1, 2, 2, 3, 3, 3])?,
                 name: "Acme Door".into(),
-                device_id: MacAddress::new([10, 20, 30, 40, 50, 60]),
+                device_id: MacAddress::from([10, 20, 30, 40, 50, 60]),
                 category: AccessoryCategory::Door,
                 ..Default::default()
             };

--- a/examples/fan.rs
+++ b/examples/fan.rs
@@ -1,7 +1,7 @@
 use tokio;
 
 use hap::{
-    accessory::{fan::FanAccessory, AccessoryCategory, AccessoryInformation},
+    accessory::{AccessoryCategory, AccessoryInformation, fan::FanAccessory},
     server::{IpServer, Server},
     storage::{FileStorage, Storage},
     Config,
@@ -29,7 +29,7 @@ async fn main() -> Result<()> {
             let config = Config {
                 pin: Pin::new([1, 1, 1, 2, 2, 3, 3, 3])?,
                 name: "Acme Fan".into(),
-                device_id: MacAddress::new([10, 20, 30, 40, 50, 60]),
+                device_id: MacAddress::from([10, 20, 30, 40, 50, 60]),
                 category: AccessoryCategory::Fan,
                 ..Default::default()
             };

--- a/examples/fan.rs
+++ b/examples/fan.rs
@@ -1,7 +1,7 @@
 use tokio;
 
 use hap::{
-    accessory::{AccessoryCategory, AccessoryInformation, fan::FanAccessory},
+    accessory::{fan::FanAccessory, AccessoryCategory, AccessoryInformation},
     server::{IpServer, Server},
     storage::{FileStorage, Storage},
     Config,

--- a/examples/fan_v2.rs
+++ b/examples/fan_v2.rs
@@ -1,7 +1,7 @@
 use tokio;
 
 use hap::{
-    accessory::{AccessoryCategory, AccessoryInformation, fan_v2::FanV2Accessory},
+    accessory::{fan_v2::FanV2Accessory, AccessoryCategory, AccessoryInformation},
     server::{IpServer, Server},
     storage::{FileStorage, Storage},
     Config,

--- a/examples/fan_v2.rs
+++ b/examples/fan_v2.rs
@@ -1,7 +1,7 @@
 use tokio;
 
 use hap::{
-    accessory::{fan_v2::FanV2Accessory, AccessoryCategory, AccessoryInformation},
+    accessory::{AccessoryCategory, AccessoryInformation, fan_v2::FanV2Accessory},
     server::{IpServer, Server},
     storage::{FileStorage, Storage},
     Config,
@@ -29,7 +29,7 @@ async fn main() -> Result<()> {
             let config = Config {
                 pin: Pin::new([1, 1, 1, 2, 2, 3, 3, 3])?,
                 name: "Acme Fan v2".into(),
-                device_id: MacAddress::new([10, 20, 30, 40, 50, 60]),
+                device_id: MacAddress::from([10, 20, 30, 40, 50, 60]),
                 category: AccessoryCategory::Fan,
                 ..Default::default()
             };

--- a/examples/faucet.rs
+++ b/examples/faucet.rs
@@ -29,7 +29,7 @@ async fn main() -> Result<()> {
             let config = Config {
                 pin: Pin::new([1, 1, 1, 2, 2, 3, 3, 3])?,
                 name: "Acme Faucet".into(),
-                device_id: MacAddress::new([10, 20, 30, 40, 50, 60]),
+                device_id: MacAddress::from([10, 20, 30, 40, 50, 60]),
                 category: AccessoryCategory::Faucet,
                 ..Default::default()
             };

--- a/examples/garage_door_opener.rs
+++ b/examples/garage_door_opener.rs
@@ -1,7 +1,7 @@
 use tokio;
 
 use hap::{
-    accessory::{garage_door_opener::GarageDoorOpenerAccessory, AccessoryCategory, AccessoryInformation},
+    accessory::{AccessoryCategory, AccessoryInformation, garage_door_opener::GarageDoorOpenerAccessory},
     server::{IpServer, Server},
     storage::{FileStorage, Storage},
     Config,
@@ -29,7 +29,7 @@ async fn main() -> Result<()> {
             let config = Config {
                 pin: Pin::new([1, 1, 1, 2, 2, 3, 3, 3])?,
                 name: "Acme Garage Door Opener".into(),
-                device_id: MacAddress::new([10, 20, 30, 40, 50, 60]),
+                device_id: MacAddress::from([10, 20, 30, 40, 50, 60]),
                 category: AccessoryCategory::GarageDoorOpener,
                 ..Default::default()
             };

--- a/examples/garage_door_opener.rs
+++ b/examples/garage_door_opener.rs
@@ -1,7 +1,7 @@
 use tokio;
 
 use hap::{
-    accessory::{AccessoryCategory, AccessoryInformation, garage_door_opener::GarageDoorOpenerAccessory},
+    accessory::{garage_door_opener::GarageDoorOpenerAccessory, AccessoryCategory, AccessoryInformation},
     server::{IpServer, Server},
     storage::{FileStorage, Storage},
     Config,

--- a/examples/heater.rs
+++ b/examples/heater.rs
@@ -29,7 +29,7 @@ async fn main() -> Result<()> {
             let config = Config {
                 pin: Pin::new([1, 1, 1, 2, 2, 3, 3, 3])?,
                 name: "Acme Heater".into(),
-                device_id: MacAddress::new([10, 20, 30, 40, 50, 60]),
+                device_id: MacAddress::from([10, 20, 30, 40, 50, 60]),
                 category: AccessoryCategory::AirHeater,
                 ..Default::default()
             };

--- a/examples/humidifier.rs
+++ b/examples/humidifier.rs
@@ -29,7 +29,7 @@ async fn main() -> Result<()> {
             let config = Config {
                 pin: Pin::new([1, 1, 1, 2, 2, 3, 3, 3])?,
                 name: "Acme Humidifier-Dehumidifier".into(),
-                device_id: MacAddress::new([10, 20, 30, 40, 50, 60]),
+                device_id: MacAddress::from([10, 20, 30, 40, 50, 60]),
                 category: AccessoryCategory::AirDehumidifier,
                 ..Default::default()
             };

--- a/examples/humidity_sensor.rs
+++ b/examples/humidity_sensor.rs
@@ -1,7 +1,7 @@
 use tokio;
 
 use hap::{
-    accessory::{AccessoryCategory, AccessoryInformation, humidity_sensor::HumiditySensorAccessory},
+    accessory::{humidity_sensor::HumiditySensorAccessory, AccessoryCategory, AccessoryInformation},
     server::{IpServer, Server},
     storage::{FileStorage, Storage},
     Config,

--- a/examples/humidity_sensor.rs
+++ b/examples/humidity_sensor.rs
@@ -1,7 +1,7 @@
 use tokio;
 
 use hap::{
-    accessory::{humidity_sensor::HumiditySensorAccessory, AccessoryCategory, AccessoryInformation},
+    accessory::{AccessoryCategory, AccessoryInformation, humidity_sensor::HumiditySensorAccessory},
     server::{IpServer, Server},
     storage::{FileStorage, Storage},
     Config,
@@ -29,7 +29,7 @@ async fn main() -> Result<()> {
             let config = Config {
                 pin: Pin::new([1, 1, 1, 2, 2, 3, 3, 3])?,
                 name: "Acme Humidity Sensor".into(),
-                device_id: MacAddress::new([10, 20, 30, 40, 50, 60]),
+                device_id: MacAddress::from([10, 20, 30, 40, 50, 60]),
                 category: AccessoryCategory::Sensor,
                 ..Default::default()
             };

--- a/examples/irrigation_system.rs
+++ b/examples/irrigation_system.rs
@@ -29,7 +29,7 @@ async fn main() -> Result<()> {
             let config = Config {
                 pin: Pin::new([1, 1, 1, 2, 2, 3, 3, 3])?,
                 name: "Acme Irrigation-System".into(),
-                device_id: MacAddress::new([10, 20, 30, 40, 50, 60]),
+                device_id: MacAddress::from([10, 20, 30, 40, 50, 60]),
                 category: AccessoryCategory::Sprinkler,
                 ..Default::default()
             };

--- a/examples/leak_sensor.rs
+++ b/examples/leak_sensor.rs
@@ -1,7 +1,7 @@
 use tokio;
 
 use hap::{
-    accessory::{leak_sensor::LeakSensorAccessory, AccessoryCategory, AccessoryInformation},
+    accessory::{AccessoryCategory, AccessoryInformation, leak_sensor::LeakSensorAccessory},
     server::{IpServer, Server},
     storage::{FileStorage, Storage},
     Config,
@@ -29,7 +29,7 @@ async fn main() -> Result<()> {
             let config = Config {
                 pin: Pin::new([1, 1, 1, 2, 2, 3, 3, 3])?,
                 name: "Acme Leak Sensor".into(),
-                device_id: MacAddress::new([10, 20, 30, 40, 50, 60]),
+                device_id: MacAddress::from([10, 20, 30, 40, 50, 60]),
                 category: AccessoryCategory::Sensor,
                 ..Default::default()
             };

--- a/examples/leak_sensor.rs
+++ b/examples/leak_sensor.rs
@@ -1,7 +1,7 @@
 use tokio;
 
 use hap::{
-    accessory::{AccessoryCategory, AccessoryInformation, leak_sensor::LeakSensorAccessory},
+    accessory::{leak_sensor::LeakSensorAccessory, AccessoryCategory, AccessoryInformation},
     server::{IpServer, Server},
     storage::{FileStorage, Storage},
     Config,

--- a/examples/light_sensor.rs
+++ b/examples/light_sensor.rs
@@ -1,7 +1,7 @@
 use tokio;
 
 use hap::{
-    accessory::{AccessoryCategory, AccessoryInformation, light_sensor::LightSensorAccessory},
+    accessory::{light_sensor::LightSensorAccessory, AccessoryCategory, AccessoryInformation},
     server::{IpServer, Server},
     storage::{FileStorage, Storage},
     Config,

--- a/examples/light_sensor.rs
+++ b/examples/light_sensor.rs
@@ -1,7 +1,7 @@
 use tokio;
 
 use hap::{
-    accessory::{light_sensor::LightSensorAccessory, AccessoryCategory, AccessoryInformation},
+    accessory::{AccessoryCategory, AccessoryInformation, light_sensor::LightSensorAccessory},
     server::{IpServer, Server},
     storage::{FileStorage, Storage},
     Config,
@@ -29,7 +29,7 @@ async fn main() -> Result<()> {
             let config = Config {
                 pin: Pin::new([1, 1, 1, 2, 2, 3, 3, 3])?,
                 name: "Acme Light Sensor".into(),
-                device_id: MacAddress::new([10, 20, 30, 40, 50, 60]),
+                device_id: MacAddress::from([10, 20, 30, 40, 50, 60]),
                 category: AccessoryCategory::Sensor,
                 ..Default::default()
             };

--- a/examples/lightbulb.rs
+++ b/examples/lightbulb.rs
@@ -29,7 +29,7 @@ async fn main() -> Result<()> {
             let config = Config {
                 pin: Pin::new([1, 1, 1, 2, 2, 3, 3, 3])?,
                 name: "Acme Lightbulb".into(),
-                device_id: MacAddress::new([10, 20, 30, 40, 50, 60]),
+                device_id: MacAddress::from([10, 20, 30, 40, 50, 60]),
                 category: AccessoryCategory::Lightbulb,
                 ..Default::default()
             };

--- a/examples/lock.rs
+++ b/examples/lock.rs
@@ -29,7 +29,7 @@ async fn main() -> Result<()> {
             let config = Config {
                 pin: Pin::new([1, 1, 1, 2, 2, 3, 3, 3])?,
                 name: "Acme Lock".into(),
-                device_id: MacAddress::new([10, 20, 30, 40, 50, 60]),
+                device_id: MacAddress::from([10, 20, 30, 40, 50, 60]),
                 category: AccessoryCategory::DoorLock,
                 ..Default::default()
             };

--- a/examples/motion_sensor.rs
+++ b/examples/motion_sensor.rs
@@ -1,7 +1,7 @@
 use tokio;
 
 use hap::{
-    accessory::{motion_sensor::MotionSensorAccessory, AccessoryCategory, AccessoryInformation},
+    accessory::{AccessoryCategory, AccessoryInformation, motion_sensor::MotionSensorAccessory},
     server::{IpServer, Server},
     storage::{FileStorage, Storage},
     Config,
@@ -29,7 +29,7 @@ async fn main() -> Result<()> {
             let config = Config {
                 pin: Pin::new([1, 1, 1, 2, 2, 3, 3, 3])?,
                 name: "Acme Motion Sensor".into(),
-                device_id: MacAddress::new([10, 20, 30, 40, 50, 60]),
+                device_id: MacAddress::from([10, 20, 30, 40, 50, 60]),
                 category: AccessoryCategory::Sensor,
                 ..Default::default()
             };

--- a/examples/motion_sensor.rs
+++ b/examples/motion_sensor.rs
@@ -1,7 +1,7 @@
 use tokio;
 
 use hap::{
-    accessory::{AccessoryCategory, AccessoryInformation, motion_sensor::MotionSensorAccessory},
+    accessory::{motion_sensor::MotionSensorAccessory, AccessoryCategory, AccessoryInformation},
     server::{IpServer, Server},
     storage::{FileStorage, Storage},
     Config,

--- a/examples/occupancy_sensor.rs
+++ b/examples/occupancy_sensor.rs
@@ -1,7 +1,7 @@
 use tokio;
 
 use hap::{
-    accessory::{AccessoryCategory, AccessoryInformation, occupancy_sensor::OccupancySensorAccessory},
+    accessory::{occupancy_sensor::OccupancySensorAccessory, AccessoryCategory, AccessoryInformation},
     server::{IpServer, Server},
     storage::{FileStorage, Storage},
     Config,

--- a/examples/occupancy_sensor.rs
+++ b/examples/occupancy_sensor.rs
@@ -1,7 +1,7 @@
 use tokio;
 
 use hap::{
-    accessory::{occupancy_sensor::OccupancySensorAccessory, AccessoryCategory, AccessoryInformation},
+    accessory::{AccessoryCategory, AccessoryInformation, occupancy_sensor::OccupancySensorAccessory},
     server::{IpServer, Server},
     storage::{FileStorage, Storage},
     Config,
@@ -29,7 +29,7 @@ async fn main() -> Result<()> {
             let config = Config {
                 pin: Pin::new([1, 1, 1, 2, 2, 3, 3, 3])?,
                 name: "Acme Occupancy Sensor".into(),
-                device_id: MacAddress::new([10, 20, 30, 40, 50, 60]),
+                device_id: MacAddress::from([10, 20, 30, 40, 50, 60]),
                 category: AccessoryCategory::Sensor,
                 ..Default::default()
             };

--- a/examples/outlet.rs
+++ b/examples/outlet.rs
@@ -1,7 +1,7 @@
 use tokio;
 
 use hap::{
-    accessory::{outlet::OutletAccessory, AccessoryCategory, AccessoryInformation},
+    accessory::{AccessoryCategory, AccessoryInformation, outlet::OutletAccessory},
     server::{IpServer, Server},
     storage::{FileStorage, Storage},
     Config,
@@ -29,7 +29,7 @@ async fn main() -> Result<()> {
             let config = Config {
                 pin: Pin::new([1, 1, 1, 2, 2, 3, 3, 3])?,
                 name: "Acme Outlet".into(),
-                device_id: MacAddress::new([10, 20, 30, 40, 50, 60]),
+                device_id: MacAddress::from([10, 20, 30, 40, 50, 60]),
                 category: AccessoryCategory::Outlet,
                 ..Default::default()
             };

--- a/examples/outlet.rs
+++ b/examples/outlet.rs
@@ -1,7 +1,7 @@
 use tokio;
 
 use hap::{
-    accessory::{AccessoryCategory, AccessoryInformation, outlet::OutletAccessory},
+    accessory::{outlet::OutletAccessory, AccessoryCategory, AccessoryInformation},
     server::{IpServer, Server},
     storage::{FileStorage, Storage},
     Config,

--- a/examples/security_system.rs
+++ b/examples/security_system.rs
@@ -1,7 +1,7 @@
 use tokio;
 
 use hap::{
-    accessory::{security_system::SecuritySystemAccessory, AccessoryCategory, AccessoryInformation},
+    accessory::{AccessoryCategory, AccessoryInformation, security_system::SecuritySystemAccessory},
     server::{IpServer, Server},
     storage::{FileStorage, Storage},
     Config,
@@ -29,7 +29,7 @@ async fn main() -> Result<()> {
             let config = Config {
                 pin: Pin::new([1, 1, 1, 2, 2, 3, 3, 3])?,
                 name: "Acme Security System".into(),
-                device_id: MacAddress::new([10, 20, 30, 40, 50, 60]),
+                device_id: MacAddress::from([10, 20, 30, 40, 50, 60]),
                 category: AccessoryCategory::SecuritySystem,
                 ..Default::default()
             };

--- a/examples/security_system.rs
+++ b/examples/security_system.rs
@@ -1,7 +1,7 @@
 use tokio;
 
 use hap::{
-    accessory::{AccessoryCategory, AccessoryInformation, security_system::SecuritySystemAccessory},
+    accessory::{security_system::SecuritySystemAccessory, AccessoryCategory, AccessoryInformation},
     server::{IpServer, Server},
     storage::{FileStorage, Storage},
     Config,

--- a/examples/setting_values_after_server_start.rs
+++ b/examples/setting_values_after_server_start.rs
@@ -31,7 +31,7 @@ async fn main() -> Result<()> {
             let config = Config {
                 pin: Pin::new([1, 1, 1, 2, 2, 3, 3, 3])?,
                 name: "Acme Sensor".into(),
-                device_id: MacAddress::new([10, 20, 30, 40, 50, 63]),
+                device_id: MacAddress::from([10, 20, 30, 40, 50, 63]),
                 category: AccessoryCategory::Sensor,
                 ..Default::default()
             };

--- a/examples/shower_head.rs
+++ b/examples/shower_head.rs
@@ -29,7 +29,7 @@ async fn main() -> Result<()> {
             let config = Config {
                 pin: Pin::new([1, 1, 1, 2, 2, 3, 3, 3])?,
                 name: "Acme Shower Head".into(),
-                device_id: MacAddress::new([10, 20, 30, 40, 50, 60]),
+                device_id: MacAddress::from([10, 20, 30, 40, 50, 60]),
                 category: AccessoryCategory::ShowerHead,
                 ..Default::default()
             };

--- a/examples/smart_speaker.rs
+++ b/examples/smart_speaker.rs
@@ -1,7 +1,7 @@
 use tokio;
 
 use hap::{
-    accessory::{AccessoryCategory, AccessoryInformation, smart_speaker::SmartSpeakerAccessory},
+    accessory::{smart_speaker::SmartSpeakerAccessory, AccessoryCategory, AccessoryInformation},
     server::{IpServer, Server},
     storage::{FileStorage, Storage},
     Config,

--- a/examples/smart_speaker.rs
+++ b/examples/smart_speaker.rs
@@ -1,7 +1,7 @@
 use tokio;
 
 use hap::{
-    accessory::{smart_speaker::SmartSpeakerAccessory, AccessoryCategory, AccessoryInformation},
+    accessory::{AccessoryCategory, AccessoryInformation, smart_speaker::SmartSpeakerAccessory},
     server::{IpServer, Server},
     storage::{FileStorage, Storage},
     Config,
@@ -29,7 +29,7 @@ async fn main() -> Result<()> {
             let config = Config {
                 pin: Pin::new([1, 1, 1, 2, 2, 3, 3, 3])?,
                 name: "Acme Smart Speaker".into(),
-                device_id: MacAddress::new([10, 20, 30, 40, 50, 60]),
+                device_id: MacAddress::from([10, 20, 30, 40, 50, 60]),
                 category: AccessoryCategory::Speaker,
                 ..Default::default()
             };

--- a/examples/smoke_sensor.rs
+++ b/examples/smoke_sensor.rs
@@ -1,7 +1,7 @@
 use tokio;
 
 use hap::{
-    accessory::{smoke_sensor::SmokeSensorAccessory, AccessoryCategory, AccessoryInformation},
+    accessory::{AccessoryCategory, AccessoryInformation, smoke_sensor::SmokeSensorAccessory},
     server::{IpServer, Server},
     storage::{FileStorage, Storage},
     Config,
@@ -29,7 +29,7 @@ async fn main() -> Result<()> {
             let config = Config {
                 pin: Pin::new([1, 1, 1, 2, 2, 3, 3, 3])?,
                 name: "Acme Smoke Sensor".into(),
-                device_id: MacAddress::new([10, 20, 30, 40, 50, 60]),
+                device_id: MacAddress::from([10, 20, 30, 40, 50, 60]),
                 category: AccessoryCategory::Sensor,
                 ..Default::default()
             };

--- a/examples/smoke_sensor.rs
+++ b/examples/smoke_sensor.rs
@@ -1,7 +1,7 @@
 use tokio;
 
 use hap::{
-    accessory::{AccessoryCategory, AccessoryInformation, smoke_sensor::SmokeSensorAccessory},
+    accessory::{smoke_sensor::SmokeSensorAccessory, AccessoryCategory, AccessoryInformation},
     server::{IpServer, Server},
     storage::{FileStorage, Storage},
     Config,

--- a/examples/stateful_programmable_switch.rs
+++ b/examples/stateful_programmable_switch.rs
@@ -1,7 +1,11 @@
 use tokio;
 
 use hap::{
-    accessory::{AccessoryCategory, AccessoryInformation, stateful_programmable_switch::StatefulProgrammableSwitchAccessory},
+    accessory::{
+        stateful_programmable_switch::StatefulProgrammableSwitchAccessory,
+        AccessoryCategory,
+        AccessoryInformation,
+    },
     server::{IpServer, Server},
     storage::{FileStorage, Storage},
     Config,

--- a/examples/stateful_programmable_switch.rs
+++ b/examples/stateful_programmable_switch.rs
@@ -1,11 +1,7 @@
 use tokio;
 
 use hap::{
-    accessory::{
-        stateful_programmable_switch::StatefulProgrammableSwitchAccessory,
-        AccessoryCategory,
-        AccessoryInformation,
-    },
+    accessory::{AccessoryCategory, AccessoryInformation, stateful_programmable_switch::StatefulProgrammableSwitchAccessory},
     server::{IpServer, Server},
     storage::{FileStorage, Storage},
     Config,
@@ -33,7 +29,7 @@ async fn main() -> Result<()> {
             let config = Config {
                 pin: Pin::new([1, 1, 1, 2, 2, 3, 3, 3])?,
                 name: "Acme Stateful Programmable Switch".into(),
-                device_id: MacAddress::new([10, 20, 30, 40, 50, 60]),
+                device_id: MacAddress::from([10, 20, 30, 40, 50, 60]),
                 category: AccessoryCategory::ProgrammableSwitch,
                 ..Default::default()
             };

--- a/examples/stateless_programmable_switch.rs
+++ b/examples/stateless_programmable_switch.rs
@@ -1,11 +1,7 @@
 use tokio;
 
 use hap::{
-    accessory::{
-        stateless_programmable_switch::StatelessProgrammableSwitchAccessory,
-        AccessoryCategory,
-        AccessoryInformation,
-    },
+    accessory::{AccessoryCategory, AccessoryInformation, stateless_programmable_switch::StatelessProgrammableSwitchAccessory},
     server::{IpServer, Server},
     storage::{FileStorage, Storage},
     Config,
@@ -33,7 +29,7 @@ async fn main() -> Result<()> {
             let config = Config {
                 pin: Pin::new([1, 1, 1, 2, 2, 3, 3, 3])?,
                 name: "Acme Stateless Programmable Switch".into(),
-                device_id: MacAddress::new([10, 20, 30, 40, 50, 60]),
+                device_id: MacAddress::from([10, 20, 30, 40, 50, 60]),
                 category: AccessoryCategory::ProgrammableSwitch,
                 ..Default::default()
             };

--- a/examples/stateless_programmable_switch.rs
+++ b/examples/stateless_programmable_switch.rs
@@ -1,7 +1,11 @@
 use tokio;
 
 use hap::{
-    accessory::{AccessoryCategory, AccessoryInformation, stateless_programmable_switch::StatelessProgrammableSwitchAccessory},
+    accessory::{
+        stateless_programmable_switch::StatelessProgrammableSwitchAccessory,
+        AccessoryCategory,
+        AccessoryInformation,
+    },
     server::{IpServer, Server},
     storage::{FileStorage, Storage},
     Config,

--- a/examples/storing_arbitrary_bytes.rs
+++ b/examples/storing_arbitrary_bytes.rs
@@ -38,7 +38,7 @@ async fn main() -> Result<()> {
             let config = Config {
                 pin: Pin::new([1, 1, 1, 2, 2, 3, 3, 3])?,
                 name: "Acme Stateful Lightbulb".into(),
-                device_id: MacAddress::new([10, 20, 30, 40, 50, 60]),
+                device_id: MacAddress::from([10, 20, 30, 40, 50, 60]),
                 category: AccessoryCategory::Lightbulb,
                 ..Default::default()
             };

--- a/examples/switch.rs
+++ b/examples/switch.rs
@@ -1,7 +1,7 @@
 use tokio;
 
 use hap::{
-    accessory::{switch::SwitchAccessory, AccessoryCategory, AccessoryInformation},
+    accessory::{AccessoryCategory, AccessoryInformation, switch::SwitchAccessory},
     server::{IpServer, Server},
     storage::{FileStorage, Storage},
     Config,
@@ -29,7 +29,7 @@ async fn main() -> Result<()> {
             let config = Config {
                 pin: Pin::new([1, 1, 1, 2, 2, 3, 3, 3])?,
                 name: "Acme Switch".into(),
-                device_id: MacAddress::new([10, 20, 30, 40, 50, 60]),
+                device_id: MacAddress::from([10, 20, 30, 40, 50, 60]),
                 category: AccessoryCategory::Switch,
                 ..Default::default()
             };

--- a/examples/switch.rs
+++ b/examples/switch.rs
@@ -1,7 +1,7 @@
 use tokio;
 
 use hap::{
-    accessory::{AccessoryCategory, AccessoryInformation, switch::SwitchAccessory},
+    accessory::{switch::SwitchAccessory, AccessoryCategory, AccessoryInformation},
     server::{IpServer, Server},
     storage::{FileStorage, Storage},
     Config,

--- a/examples/television.rs
+++ b/examples/television.rs
@@ -29,7 +29,7 @@ async fn main() -> Result<()> {
             let config = Config {
                 pin: Pin::new([1, 1, 1, 2, 2, 3, 3, 3])?,
                 name: "Acme Television".into(),
-                device_id: MacAddress::new([10, 20, 30, 40, 50, 60]),
+                device_id: MacAddress::from([10, 20, 30, 40, 50, 60]),
                 category: AccessoryCategory::Television,
                 ..Default::default()
             };

--- a/examples/temperature_sensor.rs
+++ b/examples/temperature_sensor.rs
@@ -1,7 +1,7 @@
 use tokio;
 
 use hap::{
-    accessory::{AccessoryCategory, AccessoryInformation, temperature_sensor::TemperatureSensorAccessory},
+    accessory::{temperature_sensor::TemperatureSensorAccessory, AccessoryCategory, AccessoryInformation},
     server::{IpServer, Server},
     storage::{FileStorage, Storage},
     Config,

--- a/examples/temperature_sensor.rs
+++ b/examples/temperature_sensor.rs
@@ -1,7 +1,7 @@
 use tokio;
 
 use hap::{
-    accessory::{temperature_sensor::TemperatureSensorAccessory, AccessoryCategory, AccessoryInformation},
+    accessory::{AccessoryCategory, AccessoryInformation, temperature_sensor::TemperatureSensorAccessory},
     server::{IpServer, Server},
     storage::{FileStorage, Storage},
     Config,
@@ -29,7 +29,7 @@ async fn main() -> Result<()> {
             let config = Config {
                 pin: Pin::new([1, 1, 1, 2, 2, 3, 3, 3])?,
                 name: "Acme Temperature Sensor".into(),
-                device_id: MacAddress::new([10, 20, 30, 40, 50, 60]),
+                device_id: MacAddress::from([10, 20, 30, 40, 50, 60]),
                 category: AccessoryCategory::Sensor,
                 ..Default::default()
             };

--- a/examples/thermostat.rs
+++ b/examples/thermostat.rs
@@ -1,7 +1,7 @@
 use tokio;
 
 use hap::{
-    accessory::{AccessoryCategory, AccessoryInformation, thermostat::ThermostatAccessory},
+    accessory::{thermostat::ThermostatAccessory, AccessoryCategory, AccessoryInformation},
     server::{IpServer, Server},
     storage::{FileStorage, Storage},
     Config,

--- a/examples/thermostat.rs
+++ b/examples/thermostat.rs
@@ -1,7 +1,7 @@
 use tokio;
 
 use hap::{
-    accessory::{thermostat::ThermostatAccessory, AccessoryCategory, AccessoryInformation},
+    accessory::{AccessoryCategory, AccessoryInformation, thermostat::ThermostatAccessory},
     server::{IpServer, Server},
     storage::{FileStorage, Storage},
     Config,
@@ -29,7 +29,7 @@ async fn main() -> Result<()> {
             let config = Config {
                 pin: Pin::new([1, 1, 1, 2, 2, 3, 3, 3])?,
                 name: "Acme Thermostat".into(),
-                device_id: MacAddress::new([10, 20, 30, 40, 50, 60]),
+                device_id: MacAddress::from([10, 20, 30, 40, 50, 60]),
                 category: AccessoryCategory::Thermostat,
                 ..Default::default()
             };

--- a/examples/wi_fi_router.rs
+++ b/examples/wi_fi_router.rs
@@ -1,7 +1,7 @@
 use tokio;
 
 use hap::{
-    accessory::{AccessoryCategory, AccessoryInformation, wi_fi_router::WiFiRouterAccessory},
+    accessory::{wi_fi_router::WiFiRouterAccessory, AccessoryCategory, AccessoryInformation},
     server::{IpServer, Server},
     storage::{FileStorage, Storage},
     Config,

--- a/examples/wi_fi_router.rs
+++ b/examples/wi_fi_router.rs
@@ -1,7 +1,7 @@
 use tokio;
 
 use hap::{
-    accessory::{wi_fi_router::WiFiRouterAccessory, AccessoryCategory, AccessoryInformation},
+    accessory::{AccessoryCategory, AccessoryInformation, wi_fi_router::WiFiRouterAccessory},
     server::{IpServer, Server},
     storage::{FileStorage, Storage},
     Config,
@@ -29,7 +29,7 @@ async fn main() -> Result<()> {
             let config = Config {
                 pin: Pin::new([1, 1, 1, 2, 2, 3, 3, 3])?,
                 name: "Acme Wi-Fi Router".into(),
-                device_id: MacAddress::new([10, 20, 30, 40, 50, 60]),
+                device_id: MacAddress::from([10, 20, 30, 40, 50, 60]),
                 category: AccessoryCategory::WiFiRouter,
                 ..Default::default()
             };

--- a/examples/wi_fi_satellite.rs
+++ b/examples/wi_fi_satellite.rs
@@ -1,7 +1,7 @@
 use tokio;
 
 use hap::{
-    accessory::{AccessoryCategory, AccessoryInformation, wi_fi_satellite::WiFiSatelliteAccessory},
+    accessory::{wi_fi_satellite::WiFiSatelliteAccessory, AccessoryCategory, AccessoryInformation},
     server::{IpServer, Server},
     storage::{FileStorage, Storage},
     Config,

--- a/examples/wi_fi_satellite.rs
+++ b/examples/wi_fi_satellite.rs
@@ -1,7 +1,7 @@
 use tokio;
 
 use hap::{
-    accessory::{wi_fi_satellite::WiFiSatelliteAccessory, AccessoryCategory, AccessoryInformation},
+    accessory::{AccessoryCategory, AccessoryInformation, wi_fi_satellite::WiFiSatelliteAccessory},
     server::{IpServer, Server},
     storage::{FileStorage, Storage},
     Config,
@@ -29,7 +29,7 @@ async fn main() -> Result<()> {
             let config = Config {
                 pin: Pin::new([1, 1, 1, 2, 2, 3, 3, 3])?,
                 name: "Acme Wi-Fi Satellite".into(),
-                device_id: MacAddress::new([10, 20, 30, 40, 50, 60]),
+                device_id: MacAddress::from([10, 20, 30, 40, 50, 60]),
                 category: AccessoryCategory::WiFiRouter,
                 ..Default::default()
             };

--- a/examples/window.rs
+++ b/examples/window.rs
@@ -1,7 +1,7 @@
 use tokio;
 
 use hap::{
-    accessory::{AccessoryCategory, AccessoryInformation, window::WindowAccessory},
+    accessory::{window::WindowAccessory, AccessoryCategory, AccessoryInformation},
     server::{IpServer, Server},
     storage::{FileStorage, Storage},
     Config,

--- a/examples/window.rs
+++ b/examples/window.rs
@@ -1,7 +1,7 @@
 use tokio;
 
 use hap::{
-    accessory::{window::WindowAccessory, AccessoryCategory, AccessoryInformation},
+    accessory::{AccessoryCategory, AccessoryInformation, window::WindowAccessory},
     server::{IpServer, Server},
     storage::{FileStorage, Storage},
     Config,
@@ -29,7 +29,7 @@ async fn main() -> Result<()> {
             let config = Config {
                 pin: Pin::new([1, 1, 1, 2, 2, 3, 3, 3])?,
                 name: "Acme Window".into(),
-                device_id: MacAddress::new([10, 20, 30, 40, 50, 60]),
+                device_id: MacAddress::from([10, 20, 30, 40, 50, 60]),
                 category: AccessoryCategory::Window,
                 ..Default::default()
             };

--- a/examples/window_covering.rs
+++ b/examples/window_covering.rs
@@ -1,7 +1,7 @@
 use tokio;
 
 use hap::{
-    accessory::{window_covering::WindowCoveringAccessory, AccessoryCategory, AccessoryInformation},
+    accessory::{AccessoryCategory, AccessoryInformation, window_covering::WindowCoveringAccessory},
     server::{IpServer, Server},
     storage::{FileStorage, Storage},
     Config,
@@ -29,7 +29,7 @@ async fn main() -> Result<()> {
             let config = Config {
                 pin: Pin::new([1, 1, 1, 2, 2, 3, 3, 3])?,
                 name: "Acme Window Covering".into(),
-                device_id: MacAddress::new([10, 20, 30, 40, 50, 60]),
+                device_id: MacAddress::from([10, 20, 30, 40, 50, 60]),
                 category: AccessoryCategory::WindowCovering,
                 ..Default::default()
             };

--- a/examples/window_covering.rs
+++ b/examples/window_covering.rs
@@ -1,7 +1,7 @@
 use tokio;
 
 use hap::{
-    accessory::{AccessoryCategory, AccessoryInformation, window_covering::WindowCoveringAccessory},
+    accessory::{window_covering::WindowCoveringAccessory, AccessoryCategory, AccessoryInformation},
     server::{IpServer, Server},
     storage::{FileStorage, Storage},
     Config,

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,6 @@
 use ed25519_dalek::Keypair as Ed25519Keypair;
-use eui48::MacAddress;
+//use eui48::MacAddress;
+use macaddr::MacAddr6 as MacAddress;
 use rand::{rngs::OsRng, Rng};
 use serde::{Deserialize, Serialize};
 use std::net::IpAddr;
@@ -16,7 +17,7 @@ use crate::{accessory::AccessoryCategory, BonjourFeatureFlag, BonjourStatusFlag,
 /// let config = Config {
 ///     pin: Pin::new([1, 1, 1, 2, 2, 3, 3, 3]).unwrap(),
 ///     name: "Acme Lightbulb".into(),
-///     device_id: MacAddress::new([10, 20, 30, 40, 50, 60]),
+///     device_id: MacAddress::from([10, 20, 30, 40, 50, 60]),
 ///     category: AccessoryCategory::Lightbulb,
 ///     ..Default::default()
 /// };
@@ -78,7 +79,7 @@ impl Config {
         [
             format!("c#={}", self.configuration_number),
             format!("ff={}", self.feature_flag as u8),
-            format!("id={}", self.device_id.to_hex_string()),
+            format!("id={}", self.device_id.to_string()),
             format!("md={}", self.name),
             format!("pv={}", self.protocol_version),
             format!("s#={}", self.state_number),
@@ -113,7 +114,7 @@ impl Default for Config {
 fn generate_random_mac_address() -> MacAddress {
     let mut csprng = OsRng {};
     let eui = csprng.gen::<[u8; 6]>();
-    MacAddress::new(eui)
+    MacAddress::from(eui)
 }
 
 /// Generates an Ed25519 keypair.

--- a/src/error.rs
+++ b/src/error.rs
@@ -56,7 +56,7 @@ pub enum Error {
     #[error("UTF-8 Error: {0}")]
     Utf8(#[from] str::Utf8Error),
     #[error("Parse EUI-48 Error: {0}")]
-    ParseEui48(#[from] eui48::ParseError),
+    ParseEui48(#[from] macaddr::ParseError),
     #[error("Parse Int Error: {0}")]
     ParseInt(#[from] num::ParseIntError),
     #[error("MPSC Send Error: {0}")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,6 @@
 pub use ed25519_dalek::Keypair as Ed25519Keypair;
-//pub use eui48::MacAddress;
-pub use macaddr::MacAddr6 as MacAddress;
 pub use futures;
+pub use macaddr::MacAddr6 as MacAddress;
 pub use serde_json;
 
 pub use crate::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub use ed25519_dalek::Keypair as Ed25519Keypair;
-pub use eui48::MacAddress;
+//pub use eui48::MacAddress;
+pub use macaddr::MacAddr6 as MacAddress;
 pub use futures;
 pub use serde_json;
 

--- a/src/server/ip.rs
+++ b/src/server/ip.rs
@@ -65,7 +65,7 @@ impl IpServer {
     ///             let config = Config {
     ///                 pin: Pin::new([1, 1, 1, 2, 2, 3, 3, 3])?,
     ///                 name: "Acme Lightbulb".into(),
-    ///                 device_id: MacAddress::new([10, 20, 30, 40, 50, 60]),
+    ///                 device_id: MacAddress::from([10, 20, 30, 40, 50, 60]),
     ///                 category: AccessoryCategory::Lightbulb,
     ///                 ..Default::default()
     ///             };

--- a/src/transport/http/handler/pair_setup.rs
+++ b/src/transport/http/handler/pair_setup.rs
@@ -321,7 +321,7 @@ async fn handle_exchange(
                 )?;
 
                 let config = config.lock().await;
-                let device_id = config.device_id.to_hex_string();
+                let device_id = config.device_id.to_string();
 
                 let mut accessory_info: Vec<u8> = Vec::new();
                 accessory_info.extend(&accessory_x);

--- a/src/transport/http/handler/pair_verify.rs
+++ b/src/transport/http/handler/pair_verify.rs
@@ -137,7 +137,7 @@ async fn handle_start(
     let shared_secret = b.diffie_hellman(&a_pub);
 
     let config = config.lock().await;
-    let device_id = config.device_id.to_hex_string();
+    let device_id = config.device_id.to_string();
 
     let mut accessory_info: Vec<u8> = Vec::new();
     accessory_info.extend(b_pub.as_bytes());


### PR DESCRIPTION
I ended up on this tangent because when I ran `cargo check` on main, I saw this warning:

```
warning: the following packages contain code that will be rejected by a future version of Rust: rustc-serialize v0.3.24
```

I felt like moving to `macaddr` was better than trying to fix `eui48` given how old https://github.com/abaumhauer/eui48/pull/34 is.

Given that part of this was to satisfy [`cargo audit`](https://github.com/RustSec/rustsec/tree/main/cargo-audit), I decided to bump a few dependencies.