### PR TITLE
feat: ipcamera support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,10 @@ exclude = [
     "rustfmt.toml",
 ]
 
+[features]
+camera-gstreamer18 = ["dep:gstreamer18"]
+camera-gstreamer = ["dep:gstreamer"]
+
 [dependencies]
 aead = "0.4"
 async-trait = "0.1"
@@ -30,7 +34,7 @@ ed25519-dalek = { version = "1.0", features = ["std", "serde"] }
 erased-serde = "0.3"
 macaddr = { version = "1.0.1", features = ["serde"] }
 futures = "0.3"
-get_if_addrs = "0.5"
+if-addrs = "0.13.1"
 hkdf = "0.11"
 hyper = { version = "0.14", features = ["server", "http1"] }
 libmdns = "0.6"
@@ -47,6 +51,10 @@ tokio = "1.8"
 url = "2.1"
 uuid = { version = "0.8", features = ["v4", "serde"] }
 x25519-dalek = "0.6"
+base64 = "0.22.1"
+hex = "0.4.3"
+gstreamer18 = { package = "gstreamer", version = "0.18", optional = true }
+gstreamer = { package = "gstreamer", version = "0.23", optional = true }
 
 [build-dependencies]
 handlebars = "2.0"

--- a/src/accessory/defined/camera/manager.rs
+++ b/src/accessory/defined/camera/manager.rs
@@ -1,0 +1,374 @@
+use std::{collections::HashMap, error::Error, net::IpAddr, sync::Arc};
+
+use futures::{future::BoxFuture, lock::Mutex};
+use serde_json::Value;
+use thiserror::Error;
+use uuid::Uuid;
+
+use crate::{
+    characteristic::{AsyncCharacteristicCallbacks, HapCharacteristic},
+    pointer,
+    server::Server,
+    tlv, HapType,
+};
+
+use super::{media::MediaProvider, protocol, CameraAccessory};
+
+use tokio::sync::mpsc::{channel, Sender};
+
+pub struct StreamManagerBuilder<MP>
+where
+    MP: MediaProvider,
+{
+    accessory: CameraAccessory,
+    provider: MP,
+}
+
+#[derive(Debug, Clone)]
+pub struct SessionState {
+    pub session_id: Uuid,
+    pub address: IpAddr,
+    pub video_port: u16,
+    pub audio_port: u16,
+    pub video_crypto: protocol::SetupEndpointCrypto,
+    pub audio_crypto: protocol::SetupEndpointCrypto,
+    pub video_ssrc: u32,
+    pub audio_ssrc: u32,
+}
+
+// todo: consider types to be more restricted
+#[derive(Clone, Default, Debug)]
+pub struct StreamOptions {
+    pub video: Value,
+    pub audio: Value,
+    pub srtp: bool,
+}
+
+pub struct StreamManager<MP>
+where
+    MP: MediaProvider,
+{
+    accessory: pointer::Accessory,
+    inner: Arc<Mutex<StreamManagerInner<MP>>>,
+}
+
+#[derive(Debug)]
+enum StreamingStatus {
+    Streaming,
+    Available,
+}
+
+pub struct StreamManagerInner<MP>
+where
+    MP: MediaProvider,
+{
+    streaming_status: HashMap<usize, StreamingStatus>,
+    sessions: HashMap<Uuid, SessionState>,
+    /// Setup endpoint change sender
+    sec_sender: Sender<SetupEndpointChange>,
+    /// Media provider
+    provider: MP,
+}
+
+#[derive(Debug, Error)]
+pub enum StreamManagerError {
+    #[error("Invalid accessory")]
+    InvalidAccessory,
+    #[error("Missing characteristic")]
+    MissingCharacteristic,
+    #[error("Missing session")]
+    SessionNotFound,
+    #[error("Provider error: {0}")]
+    Provider(Box<dyn Error + Send + Sync + 'static>),
+    #[error(transparent)]
+    Hap(#[from] crate::Error),
+    #[error(transparent)]
+    ProtocolError(#[from] protocol::ProtocolError),
+}
+
+struct SetupEndpointChange(usize, Vec<u8>);
+
+/// Builder adds callbacks to Camera Accessory and creates
+/// channel which allows modification of setup_endpoint characteristic
+/// from inside a callback
+impl<MP> StreamManagerBuilder<MP>
+where
+    MP: MediaProvider + Send + Sync + 'static,
+{
+    pub fn new(accessory: CameraAccessory, provider: MP) -> Self {
+        Self { accessory, provider }
+    }
+
+    /// Builder is needed because in case of Camera Accessory we have to self modify value of
+    /// setup_endpoints to create proper handshake with iOS device
+    /// Current accessory contract doesnt allow to self modify Characteristic and locks
+    /// are created when adding accessory to the server
+    pub async fn build<S>(self, server: S) -> Result<StreamManager<MP>, StreamManagerError>
+    where
+        S: Server,
+    {
+        let Self {
+            mut accessory,
+            provider,
+        } = self;
+
+        let (sec_sender, mut sec_receiver) = channel::<SetupEndpointChange>(10);
+        let mgmt = Arc::new(Mutex::new(StreamManagerInner::new(sec_sender, provider)));
+
+        for (idx, stream) in accessory.streams.iter_mut().enumerate() {
+            // set 3 characteristics responsible for streaming
+
+            // setup_endpoint
+            let m_mgmt = mgmt.clone();
+            stream
+                .setup_endpoint
+                .on_update_async(Some(move |_: tlv::Tlv8, value: tlv::Tlv8| {
+                    let mgmt = m_mgmt.clone();
+
+                    Box::pin(async move {
+                        let mut lock = mgmt.lock().await;
+                        lock.setup_endpoint(idx, value).await.map_err(Box::from)
+                    }) as BoxFuture<'static, std::result::Result<(), Box<dyn Error + Send + Sync>>>
+                }));
+
+            //  selected_stream_configuration
+            let m_mgmt = mgmt.clone();
+            stream
+                .selected_stream_configuration
+                .on_update_async(Some(move |_: tlv::Tlv8, value: tlv::Tlv8| {
+                    let mgmt = m_mgmt.clone();
+
+                    Box::pin(async move {
+                        let mut lock = mgmt.lock().await;
+                        lock.selected_stream_configuration(idx, value).await.map_err(Box::from)
+                    }) as BoxFuture<'static, std::result::Result<(), Box<dyn Error + Send + Sync>>>
+                }));
+
+            // streaming_status
+            let m_mgmt = mgmt.clone();
+            stream.streaming_status.on_read_async(Some(move || {
+                let mgmt = m_mgmt.clone();
+
+                Box::pin(async move {
+                    let mut lock = mgmt.lock().await;
+                    lock.streaming_status(idx).await
+                }) as BoxFuture<'static, std::result::Result<_, Box<dyn Error + Send + Sync>>>
+            }));
+
+            // set stream configuration options and defaults
+            let lock = mgmt.lock().await;
+            let options = lock
+                .provider()
+                .options(idx)
+                .map_err(|err| StreamManagerError::Provider(Box::new(err)))?
+                .clone();
+            log::info!("settings stream options ({idx}: {:?}", options);
+
+            stream
+                .supported_video_stream_configuration
+                .set_value(protocol::video_stream_config(options.video).into())
+                .await?;
+            stream
+                .supported_audio_stream_configuration
+                .set_value(protocol::audio_stream_config(options.audio).into())
+                .await?;
+            stream
+                .supported_rtp_configuration
+                .set_value(protocol::supported_rtp_config(options.srtp).into())
+                .await?;
+            stream
+                .streaming_status
+                .set_value(tlv::encode(vec![(0x01u8, vec![protocol::STREAMING_STATUS_AVAILABLE])]).into())
+                .await?;
+            if let Some(ref mut active) = stream.active {
+                active.set_value(1.into()).await?;
+            }
+        }
+
+        // add accessory and create Arc<Mutex<_>>
+        let accessory = server.add_accessory(accessory).await?;
+
+        // create channel which will postpone moditication of setup_endpoint
+        // so we won't encounter any deadlocks
+        let acc = accessory.clone();
+        tokio::spawn(async move {
+            while let Some(SetupEndpointChange(idx, data)) = sec_receiver.recv().await {
+                let mut acc = acc.lock().await;
+                let mut services = acc
+                    .get_mut_services()
+                    .into_iter()
+                    .filter(|s| s.get_type() == HapType::CameraStreamManagement)
+                    .collect::<Vec<_>>();
+
+                if let Some(service) = services.get_mut(idx) {
+                    if let Err(err) = service
+                        .get_mut_characteristic(HapType::SetupEndpoint)
+                        .unwrap()
+                        .set_value(data.into())
+                        .await
+                    {
+                        log::error!("cannot set setup_endpoint characteristic for stream: {idx}, {err}")
+                    }
+                }
+            }
+        });
+
+        Ok(StreamManager::new(accessory, mgmt))
+    }
+}
+
+impl<MP> StreamManagerInner<MP>
+where
+    MP: MediaProvider,
+{
+    fn new(sec_sender: Sender<SetupEndpointChange>, provider: MP) -> Self {
+        Self {
+            sec_sender,
+            provider,
+            sessions: Default::default(),
+            streaming_status: Default::default(),
+        }
+    }
+
+    fn provider(&self) -> &MP {
+        &self.provider
+    }
+
+    pub async fn setup_endpoint(
+        &mut self,
+        idx: usize,
+        value: tlv::Tlv8,
+    ) -> std::result::Result<(), StreamManagerError> {
+        log::info!("setup_endpoint({idx}): set");
+        log::trace!("setup_endpoint({idx}): {:?}", value);
+
+        let req = protocol::setup_endpoint_request(value.0.as_ref())?;
+        log::trace!("setup_endpoint({idx}): request received: {req:?}");
+
+        if self.sessions.contains_key(&req.session_id) {
+            // prevent taking action after self change
+            return Ok(());
+        }
+
+        let res = protocol::setup_endpoint_response(
+            &req,
+            self.provider
+                .address(idx)
+                .map_err(|err| StreamManagerError::Provider(Box::new(err)))?,
+        );
+        log::info!("setup_endpoint({idx}): creating session: {:?}", req.session_id);
+
+        self.sessions.insert(
+            req.session_id,
+            SessionState {
+                session_id: req.session_id,
+                address: req.ip,
+                video_port: req.video_port,
+                audio_port: req.audio_port,
+                video_crypto: req.video_crypto,
+                audio_crypto: req.audio_crypto,
+                video_ssrc: res.video_ssrc,
+                audio_ssrc: res.audio_ssrc,
+            },
+        );
+
+        if let Err(err) = self.sec_sender.send(SetupEndpointChange(idx, res.tlv)).await {
+            log::error!("cannot respond to setup_endpoint request: {err:?}");
+        }
+
+        Ok(())
+    }
+
+    pub async fn selected_stream_configuration(
+        &mut self,
+        idx: usize,
+        value: tlv::Tlv8,
+    ) -> std::result::Result<(), StreamManagerError> {
+        log::info!("selected_stream_configuration({idx}): set");
+        log::debug!("selected_stream_configuration({idx}): {:?}", value);
+
+        let req = protocol::selected_stream_configuration_request(&value.0)?;
+        let session = self
+            .sessions
+            .get(&req.session_id)
+            .ok_or(StreamManagerError::SessionNotFound)?
+            .clone();
+        log::info!("selected_stream_configuration({idx}): request: {:?}", req.session_id);
+        log::debug!("selected_stream_configuration({idx}): request: {req:?}, session: {session:?}");
+
+        match req.kind {
+            protocol::SelectedStreamRequestKind::Start => {
+                log::info!("starting stream: {idx}");
+
+                let data = protocol::stream_info_response(&value.0)?;
+
+                self.provider.start(idx, data, &session).await.map_err(|err| {
+                    self.streaming_status.insert(idx, StreamingStatus::Available);
+                    StreamManagerError::Provider(Box::new(err))
+                })?;
+
+                self.streaming_status.insert(idx, StreamingStatus::Streaming);
+            },
+            protocol::SelectedStreamRequestKind::Stop => {
+                log::info!("stopping stream: {idx}");
+
+                self.provider
+                    .stop(idx, &session)
+                    .await
+                    .map_err(|err| StreamManagerError::Provider(Box::new(err)))?;
+
+                self.streaming_status.insert(idx, StreamingStatus::Available);
+            },
+            protocol::SelectedStreamRequestKind::StartAndReconfigure => {
+                log::info!("starting and reconfiguring stream: {idx}");
+
+                let data = protocol::stream_info_response(&value.0)?;
+                self.provider.reconfigure(idx, data, &session).await.map_err(|err| {
+                    self.streaming_status.insert(idx, StreamingStatus::Available);
+                    StreamManagerError::Provider(Box::new(err))
+                })?;
+
+                self.streaming_status.insert(idx, StreamingStatus::Streaming);
+            },
+        }
+
+        Ok(())
+    }
+
+    pub async fn streaming_status(
+        &mut self,
+        idx: usize,
+    ) -> std::result::Result<Option<tlv::Tlv8>, Box<dyn Error + Send + Sync>> {
+        let status = self.streaming_status.get(&idx);
+
+        log::info!("streaming_status({idx}): read: {:?}", status);
+        log::debug!("streaming_status({idx}): read");
+
+        Ok(Some(tlv::Tlv8(tlv::encode(vec![(
+            0x01u8,
+            vec![match status {
+                Some(StreamingStatus::Available) => protocol::STREAMING_STATUS_AVAILABLE,
+                Some(StreamingStatus::Streaming) => protocol::STREAMING_STATUS_STREAMING,
+                None => protocol::STREAMING_STATUS_AVAILABLE,
+            }],
+        )]))))
+    }
+}
+
+impl<MP> StreamManager<MP>
+where
+    MP: MediaProvider,
+{
+    pub fn new(accessory: pointer::Accessory, inner: Arc<Mutex<StreamManagerInner<MP>>>) -> Self {
+        Self { accessory, inner }
+    }
+
+    pub fn accessory(&self) -> pointer::Accessory {
+        self.accessory.clone()
+    }
+
+    pub async fn sessions(&self) -> HashMap<Uuid, SessionState> {
+        let inner = self.inner.lock().await;
+        inner.sessions.clone()
+    }
+}

--- a/src/accessory/defined/camera/media/gstreamer.rs
+++ b/src/accessory/defined/camera/media/gstreamer.rs
@@ -1,0 +1,231 @@
+use std::{collections::HashMap, net::IpAddr, sync::Arc};
+
+use async_trait::async_trait;
+use thiserror::Error;
+use uuid::Uuid;
+
+use crate::accessory::camera::{
+    manager::{SessionState, StreamOptions},
+    protocol,
+};
+
+use super::MediaProvider;
+use tokio::{
+    sync::{oneshot, Mutex},
+    task::JoinHandle,
+};
+
+use gst::prelude::*;
+
+#[cfg(feature = "camera-gstreamer")]
+use gstreamer as gst;
+
+#[cfg(not(feature = "camera-gstreamer"))]
+use gstreamer18 as gst;
+
+#[derive(Clone)]
+pub struct StreamConfig {
+    pub address: IpAddr,
+    pub pipeline: String,
+    pub options: StreamOptions,
+}
+
+#[derive(Error, Debug)]
+pub enum GstreamerError {
+    #[error("stream not found")]
+    StreamNotFound,
+    #[error("cannot acquire lock")]
+    CannotAcquireLock,
+    #[error("cannot restart session")]
+    CannotRestartSession,
+    #[error("cannot find required property")]
+    MissingProperty,
+    #[error(transparent)]
+    Glib(#[from] gst::glib::Error),
+}
+
+#[derive(Clone)]
+pub struct Gstreamer {
+    configs: Vec<StreamConfig>,
+    streams: Arc<Mutex<HashMap<Uuid, HashMap<usize, StreamState>>>>,
+}
+
+pub struct StreamState {
+    _handle: JoinHandle<()>,
+    close: oneshot::Sender<oneshot::Sender<()>>,
+}
+
+impl Gstreamer {
+    pub fn new(configs: Vec<StreamConfig>) -> Result<Self, GstreamerError> {
+        gst::init()?;
+
+        Ok(Self {
+            configs,
+            streams: Default::default(),
+        })
+    }
+}
+
+impl Gstreamer {
+    fn pipeline(
+        &self,
+        idx: usize,
+        stream: protocol::StreamInfo,
+        session: &SessionState,
+    ) -> Result<String, GstreamerError> {
+        // key
+        let mut both = session.video_crypto.master_key.clone();
+        both.append(&mut session.video_crypto.master_salt.clone());
+        let key = hex::encode(&both);
+
+        let ssrc = session.video_ssrc;
+        let host = session.address.to_string();
+        let port = session.video_port;
+
+        let max_bitrate = stream
+            .video_rtp
+            .and_then(|rtp| rtp.max_bitrate)
+            .ok_or(GstreamerError::MissingProperty)?;
+        let width = stream
+            .video_attributes
+            .as_ref()
+            .map(|va| va.width)
+            .ok_or(GstreamerError::MissingProperty)?;
+        let height = stream
+            .video_attributes
+            .as_ref()
+            .map(|va| va.height)
+            .ok_or(GstreamerError::MissingProperty)?;
+        let fps = stream
+            .video_attributes
+            .as_ref()
+            .map(|va| va.fps)
+            .ok_or(GstreamerError::MissingProperty)?;
+
+        let StreamConfig { pipeline, .. } = self.configs.get(idx).ok_or(GstreamerError::StreamNotFound)?;
+
+        log::info!("video pipeline created: width: {width}, height: {height}, fps: {fps}, max_bitrate: {max_bitrate}");
+
+        Ok(format!(
+            "{pipeline} \
+            ! videorate \
+            ! video/x-raw,framerate={fps}/1 \
+            ! videoconvert \
+            ! videoscale ! video/x-raw,width={width},height={height} \
+            ! x264enc tune=zerolatency bitrate={max_bitrate} \
+            ! video/x-h264,profile=baseline \
+            ! rtph264pay config-interval=1 pt=99 ssrc={ssrc} \
+            ! srtpenc key={key} \
+            ! udpsink host={host} port={port} async=false"
+        ))
+    }
+}
+
+#[async_trait]
+impl MediaProvider for Gstreamer {
+    type Error = GstreamerError;
+
+    fn address(&self, idx: usize) -> Result<&std::net::IpAddr, GstreamerError> {
+        self.configs
+            .get(idx)
+            .map(|c| &c.address)
+            .ok_or(GstreamerError::StreamNotFound)
+    }
+
+    fn options(&self, idx: usize) -> Result<&StreamOptions, Self::Error> {
+        self.configs
+            .get(idx)
+            .map(|c| &c.options)
+            .ok_or(GstreamerError::StreamNotFound)
+    }
+
+    async fn start(&self, idx: usize, stream: protocol::StreamInfo, session: &SessionState) -> Result<(), Self::Error> {
+        let mut streams = self.streams.lock().await;
+
+        let current = streams.entry(stream.session_id).or_default();
+        if current.contains_key(&idx) {
+            return Err(GstreamerError::CannotRestartSession);
+        }
+
+        let pipeline = self.pipeline(idx, stream, session)?;
+        let (close, mut closed) = oneshot::channel::<oneshot::Sender<()>>();
+        current.insert(
+            idx,
+            StreamState {
+                close,
+                _handle: tokio::task::spawn_blocking(move || {
+                    log::info!("creating pipeline");
+
+                    log::debug!("gstreamer pipeline: {pipeline}");
+
+                    #[cfg(feature = "camera-gstreamer")]
+                    let pipeline = gst::parse::launch(&pipeline).expect("cannot build gstreamer pipeline");
+                    #[cfg(not(feature = "camera-gstreamer"))]
+                    let pipeline = gst::parse_launch(&pipeline).expect("cannot build gstreamer pipeline");
+
+                    pipeline
+                        .set_state(gst::State::Playing)
+                        .expect("cannost start streamer pipeline");
+
+                    log::info!("pipeline playing");
+
+                    let mut confirmation: Option<oneshot::Sender<()>> = None;
+
+                    let bus = pipeline.bus().unwrap();
+                    for msg in bus.iter_timed(None) {
+                        if let Ok(confirm) = closed.try_recv() {
+                            log::info!("closing gstreamer pipeline");
+                            confirmation = Some(confirm);
+                            break;
+                        }
+
+                        match msg.view() {
+                            gst::MessageView::Eos(_) => break,
+                            gst::MessageView::Error(err) => log::error!("{:?}", err),
+                            _ => (),
+                        }
+                    }
+
+                    // Clean up
+                    pipeline
+                        .set_state(gst::State::Null)
+                        .expect("cannot clean up gstreamer pipeline");
+
+                    log::info!("gstreamer pipeline finished");
+
+                    if let Some(confirm) = confirmation {
+                        let _ = confirm.send(());
+                    }
+                }),
+            },
+        );
+
+        Ok(())
+    }
+
+    async fn stop(&self, idx: usize, session: &SessionState) -> Result<(), Self::Error> {
+        let mut streams = self.streams.lock().await;
+
+        let current = streams.entry(session.session_id).or_default();
+
+        if let Some(stream) = current.remove(&idx) {
+            let (confirm, confirmed) = oneshot::channel::<()>();
+            if stream.close.send(confirm).is_ok() {
+                // during reconfiguration we have to wait for pipeline to stop
+                let _ = confirmed.await;
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn reconfigure(
+        &self,
+        idx: usize,
+        stream: protocol::StreamInfo,
+        session: &SessionState,
+    ) -> Result<(), Self::Error> {
+        self.stop(idx, session).await?;
+        self.start(idx, stream, session).await
+    }
+}

--- a/src/accessory/defined/camera/media/mod.rs
+++ b/src/accessory/defined/camera/media/mod.rs
@@ -1,0 +1,36 @@
+use std::{error::Error, net::IpAddr};
+
+use async_trait::async_trait;
+
+use super::{
+    manager::{SessionState, StreamOptions},
+    protocol,
+};
+
+#[cfg(any(feature = "camera-gstreamer", feature = "camera-gstreamer18"))]
+pub mod gstreamer;
+
+#[async_trait]
+pub trait MediaProvider {
+    type Error: Error + Send + Sync + 'static;
+
+    /// Get address of source device sending video stream
+    fn address(&self, idx: usize) -> Result<&IpAddr, Self::Error>;
+
+    /// Get available format for specified stream
+    fn options(&self, idx: usize) -> Result<&StreamOptions, Self::Error>;
+
+    /// Start video stream
+    async fn start(&self, idx: usize, stream: protocol::StreamInfo, session: &SessionState) -> Result<(), Self::Error>;
+
+    /// Reconfigure video stream
+    async fn reconfigure(
+        &self,
+        idx: usize,
+        stream: protocol::StreamInfo,
+        session: &SessionState,
+    ) -> Result<(), Self::Error>;
+
+    /// Stop video stream
+    async fn stop(&self, idx: usize, session: &SessionState) -> Result<(), Self::Error>;
+}

--- a/src/accessory/defined/camera/mod.rs
+++ b/src/accessory/defined/camera/mod.rs
@@ -1,0 +1,112 @@
+use crate::{accessory::{AccessoryInformation, HapAccessory}, characteristic::HapCharacteristic, service::{accessory_information::AccessoryInformationService, camera_stream_management::CameraStreamManagementService, microphone::MicrophoneService, HapService}, HapType, Result};
+
+use futures::executor;
+use serde::{
+    ser::{SerializeStruct, Serializer},
+    Serialize,
+};
+
+pub mod protocol;
+pub mod manager;
+pub mod media;
+
+/// Camera Accessory.
+#[derive(Default, Debug)]
+pub struct CameraAccessory {
+    /// ID of the Foo accessory.
+    id: u64,
+
+    /// Accessory Information service.
+    pub accessory_information: AccessoryInformationService,
+
+    /// Microphone
+    pub microphone: MicrophoneService,
+
+    /// Camera streams
+    pub streams: Vec<CameraStreamManagementService>,
+}
+
+impl HapAccessory for CameraAccessory {
+    fn get_id(&self) -> u64 {
+        self.id
+    }
+
+    fn set_id(&mut self, id: u64) {
+        self.id = id;
+    }
+
+    fn get_service(&self, hap_type: HapType) -> Option<&dyn HapService> {
+        for service in self.get_services() {
+            if service.get_type() == hap_type {
+                return Some(service);
+            }
+        }
+        None
+    }
+
+    fn get_mut_service(&mut self, hap_type: HapType) -> Option<&mut dyn HapService> {
+        for service in self.get_mut_services() {
+            if service.get_type() == hap_type {
+                return Some(service);
+            }
+        }
+        None
+    }
+
+    fn get_services(&self) -> Vec<&dyn HapService> {
+        let mut services: Vec<&dyn HapService> =
+            vec![&self.accessory_information, &self.microphone];
+        services.append(&mut self.streams.iter().map(|s| s as &dyn HapService).collect());
+        services
+    }
+
+    fn get_mut_services(&mut self) -> Vec<&mut dyn HapService> {
+        let mut services: Vec<&mut dyn HapService> =
+            vec![&mut self.accessory_information, &mut self.microphone];
+        services.append(
+            &mut self
+                .streams
+                .iter_mut()
+                .map(|s| s as &mut dyn HapService)
+                .collect(),
+        );
+        services
+    }
+}
+
+impl Serialize for CameraAccessory {
+    fn serialize<S: Serializer>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error> {
+        let mut state = serializer.serialize_struct("HapAccessory", 2)?;
+        state.serialize_field("aid", &self.get_id())?;
+        state.serialize_field("services", &self.get_services())?;
+        state.end()
+    }
+}
+
+impl CameraAccessory {
+    /// Creates a new Camera Accessory.
+    pub fn new(id: u64, streams_count: usize, information: AccessoryInformation) -> Result<Self> {
+        let accessory_information = information.to_service(1, id)?;
+
+        let microphone_id = 2 + accessory_information.get_characteristics().len() as u64;
+        let mut microphone = MicrophoneService::new(microphone_id, id);
+
+        executor::block_on(microphone.mute.set_value(0.into()))?;
+
+        // create streams
+        let mut stream_id = 3 + microphone_id + microphone.get_characteristics().len() as u64;
+        let mut streams = vec![];
+        for _ in 0..streams_count {
+            let s = CameraStreamManagementService::new(stream_id, id);
+            stream_id += 1 + s.get_characteristics().len() as u64;
+            streams.push(s);
+        }
+
+        Ok(Self {
+            id,
+            accessory_information,
+            microphone,
+            streams,
+        })
+    }
+}

--- a/src/accessory/defined/camera/protocol.rs
+++ b/src/accessory/defined/camera/protocol.rs
@@ -1,0 +1,902 @@
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+use crate::tlv::{decode, encode};
+use rand::RngCore;
+use std::str::FromStr;
+use thiserror::Error;
+use uuid::Uuid;
+
+pub const SETUP_TYPES_SESSION_ID: u8 = 0x01;
+pub const SETUP_TYPES_STATUS: u8 = 0x02;
+pub const SETUP_TYPES_ADDRESS: u8 = 0x03;
+pub const SETUP_TYPES_VIDEO_SRTP_PARAM: u8 = 0x04;
+pub const SETUP_TYPES_AUDIO_SRTP_PARAM: u8 = 0x05;
+pub const SETUP_TYPES_VIDEO_SSRC: u8 = 0x06;
+pub const SETUP_TYPES_AUDIO_SSRC: u8 = 0x07;
+
+pub const SETUP_STATUS_SUCCESS: u8 = 0x00;
+pub const SETUP_STATUS_BUSY: u8 = 0x01;
+pub const SETUP_STATUS_ERROR: u8 = 0x02;
+
+pub const SETUP_IPV_IPV4: u8 = 0x00;
+pub const SETUP_IPV_IPV6: u8 = 0x01;
+
+pub const SETUP_ADDR_INFO_ADDRESS_VER: u8 = 0x01;
+pub const SETUP_ADDR_INFO_ADDRESS: u8 = 0x02;
+pub const SETUP_ADDR_INFO_VIDEO_RTP_PORT: u8 = 0x03;
+pub const SETUP_ADDR_INFO_AUDIO_RTP_PORT: u8 = 0x04;
+
+pub const SETUP_SRTP_PARAM_CRYPTO: u8 = 0x01;
+pub const SETUP_SRTP_PARAM_MASTER_KEY: u8 = 0x02;
+pub const SETUP_SRTP_PARAM_MASTER_SALT: u8 = 0x03;
+
+pub const STREAMING_STATUS_AVAILABLE: u8 = 0x00;
+pub const STREAMING_STATUS_STREAMING: u8 = 0x01;
+pub const STREAMING_STATUS_BUSY: u8 = 0x02;
+
+pub const RTP_CONFIG_TYPES_CRYPTO: u8 = 0x02;
+
+pub const SRTP_CRYPTO_SUITES_AES_CM_128_HMAC_SHA1_80: u8 = 0x00;
+pub const SRTP_CRYPTO_SUITES_AES_CM_256_HMAC_SHA1_80: u8 = 0x01;
+pub const SRTP_CRYPTO_SUITES_NONE: u8 = 0x02;
+
+pub const VIDEO_TYPES_CODEC: u8 = 0x01;
+pub const VIDEO_TYPES_CODEC_PARAM: u8 = 0x02;
+pub const VIDEO_TYPES_ATTRIBUTES: u8 = 0x03;
+pub const VIDEO_TYPES_RTP_PARAM: u8 = 0x04;
+
+pub const VIDEO_CODEC_TYPES_H264: u8 = 0x00;
+
+pub const VIDEO_CODEC_PARAM_TYPES_PROFILE_ID: u8 = 0x01;
+pub const VIDEO_CODEC_PARAM_TYPES_LEVEL: u8 = 0x02;
+pub const VIDEO_CODEC_PARAM_TYPES_PACKETIZATION_MODE: u8 = 0x03;
+pub const VIDEO_CODEC_PARAM_TYPES_CVO_ENABLED: u8 = 0x04;
+pub const VIDEO_CODEC_PARAM_TYPES_CVO_ID: u8 = 0x05;
+
+pub const VIDEO_CODEC_PARAM_CVO_TYPES_UNSUPPORTED: u8 = 0x01;
+pub const VIDEO_CODEC_PARAM_CVO_TYPES_SUPPORTED: u8 = 0x02;
+
+pub const VIDEO_CODEC_PARAM_PROFILE_ID_TYPES_BASELINE: u8 = 0x00;
+pub const VIDEO_CODEC_PARAM_PROFILE_ID_TYPES_MAIN: u8 = 0x01;
+pub const VIDEO_CODEC_PARAM_PROFILE_ID_TYPES_HIGH: u8 = 0x02;
+
+pub const VIDEO_CODEC_PARAM_LEVEL_TYPES_TYPE3_1: u8 = 0x00;
+pub const VIDEO_CODEC_PARAM_LEVEL_TYPES_TYPE3_2: u8 = 0x01;
+pub const VIDEO_CODEC_PARAM_LEVEL_TYPES_TYPE4_0: u8 = 0x02;
+
+pub const VIDEO_CODEC_PARAM_PACKETIZATION_MODE_TYPES_NON_INTERLEAVED: u8 = 0x00;
+
+pub const VIDEO_ATTRIBUTES_TYPES_IMAGE_WIDTH: u8 = 0x01;
+pub const VIDEO_ATTRIBUTES_TYPES_IMAGE_HEIGHT: u8 = 0x02;
+pub const VIDEO_ATTRIBUTES_TYPES_FRAME_RATE: u8 = 0x03;
+
+pub const SUPPORTED_VIDEO_CONFIG_TAG: u8 = 0x01;
+
+pub const SELECTED_STREAM_CONFIGURATION_TYPES_SESSION: u8 = 0x01;
+pub const SELECTED_STREAM_CONFIGURATION_TYPES_VIDEO: u8 = 0x02;
+pub const SELECTED_STREAM_CONFIGURATION_TYPES_AUDIO: u8 = 0x03;
+
+pub const RTP_PARAM_TYPES_PAYLOAD_TYPE: u8 = 0x01;
+pub const RTP_PARAM_TYPES_SYNCHRONIZATION_SOURCE: u8 = 0x02;
+pub const RTP_PARAM_TYPES_MAX_BIT_RATE: u8 = 0x03;
+pub const RTP_PARAM_TYPES_RTCP_SEND_INTERVAL: u8 = 0x04;
+pub const RTP_PARAM_TYPES_MAX_MTU: u8 = 0x05;
+pub const RTP_PARAM_TYPES_COMFORT_NOISE_PAYLOAD_TYPE: u8 = 0x06;
+
+pub const AUDIO_TYPES_CODEC: u8 = 0x01;
+pub const AUDIO_TYPES_CODEC_PARAM: u8 = 0x02;
+pub const AUDIO_TYPES_RTP_PARAM: u8 = 0x03;
+pub const AUDIO_TYPES_COMFORT_NOISE: u8 = 0x04;
+
+pub const AUDIO_CODEC_TYPES_PCMU: u8 = 0x00;
+pub const AUDIO_CODEC_TYPES_PCMA: u8 = 0x01;
+pub const AUDIO_CODEC_TYPES_AACELD: u8 = 0x02;
+pub const AUDIO_CODEC_TYPES_OPUS: u8 = 0x03;
+
+pub const AUDIO_CODEC_PARAM_TYPES_CHANNEL: u8 = 0x01;
+pub const AUDIO_CODEC_PARAM_TYPES_BIT_RATE: u8 = 0x02;
+pub const AUDIO_CODEC_PARAM_TYPES_SAMPLE_RATE: u8 = 0x03;
+pub const AUDIO_CODEC_PARAM_TYPES_PACKET_TIME: u8 = 0x04;
+
+pub const AUDIO_CODEC_PARAM_BIT_RATE_TYPES_VARIABLE: u8 = 0x00;
+pub const AUDIO_CODEC_PARAM_BIT_RATE_TYPES_CONSTANT: u8 = 0x01;
+
+pub const AUDIO_CODEC_PARAM_SAMPLE_RATE_TYPES_KHZ_8: u8 = 0x00;
+pub const AUDIO_CODEC_PARAM_SAMPLE_RATE_TYPES_KHZ_16: u8 = 0x01;
+pub const AUDIO_CODEC_PARAM_SAMPLE_RATE_TYPES_KHZ_24: u8 = 0x02;
+
+pub const SUPPORTED_AUDIO_CODECS_TAG: u8 = 0x01;
+pub const SUPPORTED_COMFORT_NOISE_TAG: u8 = 0x02;
+pub const SUPPORTED_AUDIO_CONFIG_TAG: u8 = 0x02;
+pub const SET_CONFIG_REQUEST_TAG: u8 = 0x02;
+pub const SESSION_ID: u8 = 0x01;
+
+pub const NO_SRTP: [u8; 7] = [0x01, 0x01, 0x02, 0x02, 0x00, 0x03, 0x00];
+
+#[derive(Debug)]
+pub struct SetupEndpointRequest {
+    pub session_id: Uuid,
+    pub ip: IpAddr,
+    pub video_port: u16,
+    pub audio_port: u16,
+    pub video_crypto: SetupEndpointCrypto,
+    pub audio_crypto: SetupEndpointCrypto,
+}
+
+#[derive(Debug)]
+pub struct SelectedStreamRequest {
+    pub session_id: Uuid,
+    pub kind: SelectedStreamRequestKind,
+}
+
+#[derive(Debug)]
+pub enum SelectedStreamRequestKind {
+    Start,
+    Stop,
+    StartAndReconfigure,
+}
+
+#[derive(Debug, Clone)]
+pub struct SetupEndpointCrypto {
+    pub cypto_suite: u8,
+    pub master_key: Vec<u8>,
+    pub master_salt: Vec<u8>,
+}
+
+#[derive(Debug, Error)]
+pub enum ProtocolError {
+    #[error("Property cannot be found")]
+    MissingProperty,
+    #[error("Cannot convert to array")]
+    ArrayConversion,
+    #[error("Cannot parse string to utf8")]
+    Utf8,
+    #[error("Ip cannot be parsed: {0}")]
+    Ip(String),
+}
+
+#[derive(Debug)]
+pub struct StreamInfo {
+    pub session_id: Uuid,
+    pub video_codec: Option<StreamVideoCodec>,
+    pub video_attributes: Option<StreamVideoAttributes>,
+    pub video_rtp: Option<StreamVideoRtp>,
+    pub audio: Option<StreamAudio>,
+}
+
+impl StreamInfo {
+    pub fn new(session_id: Uuid) -> Self {
+        Self {
+            session_id,
+            video_codec: Default::default(),
+            video_attributes: Default::default(),
+            video_rtp: Default::default(),
+            audio: Default::default(),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct StreamVideoAttributes {
+    pub width: u16,
+    pub height: u16,
+    pub fps: u8,
+}
+
+#[derive(Debug)]
+pub struct StreamVideoCodec {
+    pub profile_id: Vec<u8>,
+    pub level: Vec<u8>,
+}
+
+#[derive(Debug)]
+pub struct StreamVideoRtp {
+    pub ssrc: Option<u32>,
+    pub payload_type: Option<Vec<u8>>,
+    pub max_bitrate: Option<u16>,
+    pub rtcp_interval: Option<f32>,
+    pub max_mtu: Option<Vec<u8>>,
+}
+
+#[derive(Debug)]
+pub struct StreamAudio {
+    pub codec: Vec<u8>,
+    pub comfort_noise: Vec<u8>,
+
+    pub channel: u8,
+    pub bitrate: bool,
+    pub sample_rate: u8,
+    pub packet_time: u8,
+
+    pub ssrc: u32,
+    pub payload_type: Vec<u8>,
+    pub max_bitrate: u16,
+    pub rtcp_interval: f32,
+    pub comfort_payload_type: Vec<u8>,
+}
+
+#[derive(Debug)]
+pub struct EndpointResponse {
+    pub tlv: Vec<u8>,
+    pub video_ssrc: u32,
+    pub audio_ssrc: u32,
+}
+
+pub(crate) fn setup_endpoint_response(request: &SetupEndpointRequest, address: &IpAddr) -> EndpointResponse {
+    let (video_srtp_tlv, audio_srtp_tlv) = if true {
+        let video = encode(vec![
+            (
+                SETUP_SRTP_PARAM_CRYPTO,
+                vec![SRTP_CRYPTO_SUITES_AES_CM_128_HMAC_SHA1_80],
+            ),
+            (SETUP_SRTP_PARAM_MASTER_KEY, request.video_crypto.master_key.clone()),
+            (SETUP_SRTP_PARAM_MASTER_SALT, request.video_crypto.master_salt.clone()),
+        ]);
+
+        let audio = encode(vec![
+            (
+                SETUP_SRTP_PARAM_CRYPTO,
+                vec![SRTP_CRYPTO_SUITES_AES_CM_128_HMAC_SHA1_80],
+            ),
+            (SETUP_SRTP_PARAM_MASTER_KEY, request.audio_crypto.master_key.clone()),
+            (SETUP_SRTP_PARAM_MASTER_SALT, request.audio_crypto.master_salt.clone()),
+        ]);
+
+        (video, audio)
+    } else {
+        (NO_SRTP.to_vec(), NO_SRTP.to_vec())
+    };
+
+    let mut data = [0u8; 4];
+    rand::thread_rng().fill_bytes(&mut data);
+    let video_ssrc = u32::from_le_bytes(data);
+    rand::thread_rng().fill_bytes(&mut data);
+    let audio_ssrc = u32::from_le_bytes(data);
+
+    let res_address_tlv = encode(vec![
+        (
+            SETUP_ADDR_INFO_ADDRESS_VER,
+            vec![if address.is_ipv6() { 0x01 } else { 0x00 }],
+        ),
+        (SETUP_ADDR_INFO_ADDRESS, address.to_string().as_bytes().to_vec()),
+        (
+            SETUP_ADDR_INFO_VIDEO_RTP_PORT,
+            request.video_port.to_le_bytes().to_vec(),
+        ),
+        (
+            SETUP_ADDR_INFO_AUDIO_RTP_PORT,
+            request.audio_port.to_le_bytes().to_vec(),
+        ),
+    ]);
+
+    let tlv = encode(vec![
+        (
+            SETUP_TYPES_SESSION_ID,
+            request.session_id.to_u128_le().to_le_bytes().to_vec(),
+        ),
+        (SETUP_TYPES_STATUS, vec![SETUP_STATUS_SUCCESS]),
+        (SETUP_TYPES_ADDRESS, res_address_tlv),
+        (SETUP_TYPES_VIDEO_SRTP_PARAM, video_srtp_tlv),
+        (SETUP_TYPES_AUDIO_SRTP_PARAM, audio_srtp_tlv),
+        (SETUP_TYPES_VIDEO_SSRC, video_ssrc.to_le_bytes().to_vec()),
+        (SETUP_TYPES_AUDIO_SSRC, audio_ssrc.to_le_bytes().to_vec()),
+    ]);
+
+    EndpointResponse {
+        tlv,
+        video_ssrc,
+        audio_ssrc,
+    }
+}
+
+pub(crate) fn setup_endpoint_request(bytes: &[u8]) -> std::result::Result<SetupEndpointRequest, ProtocolError> {
+    let objs = decode(bytes);
+
+    let session_id = objs
+        .get(&SETUP_TYPES_SESSION_ID)
+        .ok_or(ProtocolError::MissingProperty)?;
+
+    let session_id = Uuid::from_bytes(
+        session_id
+            .clone()
+            .try_into()
+            .map_err(|_| ProtocolError::ArrayConversion)?,
+    );
+
+    let address_tlv = objs.get(&SETUP_TYPES_ADDRESS).ok_or(ProtocolError::MissingProperty)?;
+    let address = decode(address_tlv);
+
+    let is_ipv6 = address
+        .get(&SETUP_ADDR_INFO_ADDRESS_VER)
+        .ok_or(ProtocolError::MissingProperty)?
+        .first()
+        .ok_or(ProtocolError::MissingProperty)?;
+
+    let is_ipv6 = *is_ipv6 != 0;
+
+    let addr = address
+        .get(&SETUP_ADDR_INFO_ADDRESS)
+        .ok_or(ProtocolError::MissingProperty)?;
+    let plain = std::str::from_utf8(addr).map_err(|_| ProtocolError::Utf8)?;
+
+    let ip = if is_ipv6 {
+        IpAddr::V6(Ipv6Addr::from_str(plain).map_err(|_| ProtocolError::Ip(plain.to_string()))?)
+    } else {
+        IpAddr::V4(Ipv4Addr::from_str(plain).map_err(|_| ProtocolError::Ip(plain.to_string()))?)
+    };
+
+    let target_video_port = address
+        .get(&SETUP_ADDR_INFO_VIDEO_RTP_PORT)
+        .ok_or(ProtocolError::MissingProperty)?;
+    let video_port = u16::from_le_bytes(
+        target_video_port
+            .clone()
+            .try_into()
+            .map_err(|_| ProtocolError::ArrayConversion)?,
+    );
+
+    let target_audio_port = address
+        .get(&SETUP_ADDR_INFO_AUDIO_RTP_PORT)
+        .ok_or(ProtocolError::MissingProperty)?;
+    let audio_port = u16::from_le_bytes(
+        target_audio_port
+            .clone()
+            .try_into()
+            .map_err(|_| ProtocolError::ArrayConversion)?,
+    );
+
+    // video srtp params
+    let video_srtp_tlv = objs
+        .get(&SETUP_TYPES_VIDEO_SRTP_PARAM)
+        .ok_or(ProtocolError::MissingProperty)?;
+
+    let video_srtp = decode(video_srtp_tlv);
+    let video_crypto_suite = video_srtp
+        .get(&SETUP_SRTP_PARAM_CRYPTO)
+        .ok_or(ProtocolError::MissingProperty)?
+        .first()
+        .ok_or(ProtocolError::MissingProperty)?;
+
+    let video_master_key = video_srtp
+        .get(&SETUP_SRTP_PARAM_MASTER_KEY)
+        .ok_or(ProtocolError::MissingProperty)?;
+    let video_master_salt = video_srtp
+        .get(&SETUP_SRTP_PARAM_MASTER_SALT)
+        .ok_or(ProtocolError::MissingProperty)?;
+
+    let video_crypto = SetupEndpointCrypto {
+        cypto_suite: *video_crypto_suite,
+        master_key: video_master_key.clone(),
+        master_salt: video_master_salt.clone(),
+    };
+
+    // audio srtp params
+    let audio_srtp_tlv = objs
+        .get(&SETUP_TYPES_AUDIO_SRTP_PARAM)
+        .ok_or(ProtocolError::MissingProperty)?;
+    let audio_srtp = decode(audio_srtp_tlv);
+    let audio_crypto_suite = audio_srtp.get(&SETUP_SRTP_PARAM_CRYPTO).unwrap().first().unwrap();
+    let audio_master_key = audio_srtp
+        .get(&SETUP_SRTP_PARAM_MASTER_KEY)
+        .ok_or(ProtocolError::MissingProperty)?;
+    let audio_master_salt = audio_srtp
+        .get(&SETUP_SRTP_PARAM_MASTER_SALT)
+        .ok_or(ProtocolError::MissingProperty)?;
+
+    let audio_crypto = SetupEndpointCrypto {
+        cypto_suite: *audio_crypto_suite,
+        master_key: audio_master_key.clone(),
+        master_salt: audio_master_salt.clone(),
+    };
+
+    Ok(SetupEndpointRequest {
+        session_id,
+        ip,
+        video_port,
+        audio_port,
+        video_crypto,
+        audio_crypto,
+    })
+}
+
+pub(crate) fn supported_rtp_config(enabled: bool) -> Vec<u8> {
+    let support_srtp = if enabled {
+        SRTP_CRYPTO_SUITES_AES_CM_128_HMAC_SHA1_80
+    } else {
+        SRTP_CRYPTO_SUITES_NONE
+    };
+
+    encode(vec![(RTP_CONFIG_TYPES_CRYPTO, vec![support_srtp])])
+}
+
+pub(crate) fn video_stream_config(data: serde_json::Value) -> Vec<u8> {
+    // profiles
+    let mut profiles = if let serde_json::Value::Array(arr) = &data["codec"]["profiles"] {
+        let mut result = arr
+            .iter()
+            .filter_map(|v| match v {
+                serde_json::Value::Number(n) => n.as_u64().map(|u| u as u8),
+                _ => None,
+            })
+            .map(|profile| {
+                let mut bytes = encode(vec![(0x01, vec![profile])]);
+                bytes.push(0x00);
+                bytes.push(0x00);
+                bytes
+            })
+            .flatten()
+            .collect::<Vec<u8>>();
+
+        result.pop();
+        result.pop();
+
+        result
+    } else {
+        vec![]
+    };
+
+    // levels
+    let mut levels = if let serde_json::Value::Array(arr) = &data["codec"]["levels"] {
+        let mut result = arr
+            .iter()
+            .filter_map(|v| match v {
+                serde_json::Value::Number(n) => n.as_u64().map(|u| u as u8),
+                _ => None,
+            })
+            .map(|lvl| {
+                let mut bytes = encode(vec![(0x02, vec![lvl])]);
+                bytes.push(0x00);
+                bytes.push(0x00);
+                bytes
+            })
+            .flatten()
+            .collect::<Vec<u8>>();
+
+        result.pop();
+        result.pop();
+
+        result
+    } else {
+        vec![]
+    };
+
+    let mut codec_params_tlv = vec![];
+    codec_params_tlv.append(&mut profiles);
+    codec_params_tlv.append(&mut levels);
+    codec_params_tlv.append(&mut encode(vec![(0x03, vec![0x00])]));
+
+    // resolutions
+    let mut attr_tlv = vec![];
+    if let serde_json::Value::Array(arr) = &data["resolutions"] {
+        let u16_list = arr
+            .iter()
+            .filter_map(|v| match v {
+                serde_json::Value::Array(ref list) => {
+                    let dims = list
+                        .iter()
+                        .filter_map(|v| match v {
+                            serde_json::Value::Number(n) => n.as_u64().map(|u| u as u16),
+                            _ => None,
+                        })
+                        .collect::<Vec<u16>>();
+
+                    if let [a, b, c] = dims[..] {
+                        Some((a, b, c))
+                    } else {
+                        None
+                    }
+                },
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+
+        for (width, height, rate) in u16_list {
+            let res_tlv = encode(vec![
+                (0x01, width.to_le_bytes().to_vec()),
+                (0x02, height.to_le_bytes().to_vec()),
+                (0x03, (rate as u8).to_le_bytes().to_vec()),
+            ]);
+
+            attr_tlv.append(&mut encode(vec![(0x03, res_tlv)]));
+
+            // delimiter
+            attr_tlv.push(0x00);
+            attr_tlv.push(0x00);
+        }
+
+        attr_tlv.pop();
+        attr_tlv.pop();
+    }
+
+    let mut config_tlv = encode(vec![(0x01, vec![0x00]), (0x02, codec_params_tlv)]);
+
+    config_tlv.append(&mut attr_tlv);
+
+    encode(vec![(0x01, config_tlv)])
+}
+
+pub(crate) fn audio_stream_config(data: serde_json::Value) -> Vec<u8> {
+    #[derive(serde::Deserialize)]
+    struct Codec {
+        r#type: String,
+        samplerate: u8,
+    }
+
+    let mut configs = vec![];
+
+    // codecs
+    let codecs = serde_json::from_value::<Vec<Codec>>(data["codecs"].clone()).unwrap();
+    for codec in codecs {
+        let (c, bitrate) = match codec.r#type.as_str() {
+            "OPUS" => (0x03, 0x00u8),
+            "AAC-eld" => (0x02, 0x00),
+            _ => panic!("unsupported codec"),
+        };
+
+        let samplerate = match codec.samplerate {
+            8u8 => 0x00u8,
+            16 => 0x01,
+            24 => 0x02,
+            _ => panic!("unsupported samplerate"),
+        };
+
+        let param_tlv = encode(vec![
+            (0x01, vec![0x01]),
+            (0x02, bitrate.to_le_bytes().to_vec()),
+            (0x03, samplerate.to_le_bytes().to_vec()),
+        ]);
+
+        let config_tlv = encode(vec![(0x01, vec![c]), (0x02, param_tlv)]);
+
+        configs.append(&mut encode(vec![(0x01, config_tlv)]));
+    }
+
+    // todo: handle panic
+
+    configs.append(&mut encode(vec![(0x02, vec![0x00])])); // comfort noise; 0x00 - false, 0x01 - true
+
+    configs
+}
+
+pub(crate) fn stream_info_response(bytes: &[u8]) -> std::result::Result<StreamInfo, ProtocolError> {
+    let objs = decode(bytes);
+    let session_objs = decode(
+        objs.get(&SELECTED_STREAM_CONFIGURATION_TYPES_SESSION)
+            .ok_or(ProtocolError::MissingProperty)?,
+    );
+
+    let session_id = session_objs
+        .get(&SETUP_TYPES_SESSION_ID)
+        .ok_or(ProtocolError::MissingProperty)?;
+
+    let session_id = Uuid::from_bytes(
+        session_id
+            .clone()
+            .try_into()
+            .map_err(|_| ProtocolError::ArrayConversion)?,
+    );
+
+    let mut info = StreamInfo::new(session_id);
+
+    // video
+    if let Some(video_tlv) = objs.get(&SELECTED_STREAM_CONFIGURATION_TYPES_VIDEO) {
+        let video_objs = decode(&video_tlv);
+
+        if let Some(video_codec_params_tlv) = video_objs.get(&VIDEO_TYPES_CODEC_PARAM) {
+            let video_codec_params_objs = decode(&video_codec_params_tlv);
+
+            info.video_codec = Some(StreamVideoCodec {
+                profile_id: video_codec_params_objs
+                    .get(&VIDEO_CODEC_PARAM_TYPES_PROFILE_ID)
+                    .ok_or(ProtocolError::MissingProperty)?
+                    .clone(),
+                level: video_codec_params_objs
+                    .get(&VIDEO_CODEC_PARAM_TYPES_LEVEL)
+                    .ok_or(ProtocolError::MissingProperty)?
+                    .clone(),
+            });
+        }
+
+        if let Some(video_attrs_tlv) = video_objs.get(&VIDEO_TYPES_ATTRIBUTES) {
+            let video_attrs_objs = decode(&video_attrs_tlv);
+
+            info.video_attributes = Some(StreamVideoAttributes {
+                width: u16::from_le_bytes(
+                    video_attrs_objs
+                        .get(&VIDEO_ATTRIBUTES_TYPES_IMAGE_WIDTH)
+                        .ok_or(ProtocolError::MissingProperty)?
+                        .clone()
+                        .try_into()
+                        .map_err(|_| ProtocolError::ArrayConversion)?,
+                ),
+                height: u16::from_le_bytes(
+                    video_attrs_objs
+                        .get(&VIDEO_ATTRIBUTES_TYPES_IMAGE_HEIGHT)
+                        .ok_or(ProtocolError::MissingProperty)?
+                        .clone()
+                        .try_into()
+                        .map_err(|_| ProtocolError::ArrayConversion)?,
+                ),
+                fps: video_attrs_objs
+                    .get(&VIDEO_ATTRIBUTES_TYPES_FRAME_RATE)
+                    .ok_or(ProtocolError::MissingProperty)?
+                    .first()
+                    .cloned()
+                    .ok_or(ProtocolError::MissingProperty)?,
+            });
+        }
+
+        if let Some(video_rtp_param_tlv) = video_objs.get(&VIDEO_TYPES_RTP_PARAM) {
+            let video_rtp_param_objs = decode(&video_rtp_param_tlv);
+
+            info.video_rtp = Some(StreamVideoRtp {
+                ssrc: video_rtp_param_objs
+                    .get(&RTP_PARAM_TYPES_SYNCHRONIZATION_SOURCE)
+                    .map(|bytes| bytes.clone().try_into() as Result<[u8; 4], _>)
+                    .map_or(Ok(None), |v| v.map(Some))
+                    .map_err(|_| ProtocolError::ArrayConversion)?
+                    .map(u32::from_le_bytes),
+                payload_type: video_rtp_param_objs.get(&RTP_PARAM_TYPES_PAYLOAD_TYPE).cloned(),
+                max_bitrate: video_rtp_param_objs
+                    .get(&RTP_PARAM_TYPES_MAX_BIT_RATE)
+                    .map(|bytes| bytes.clone().try_into() as Result<[u8; 2], _>)
+                    .map_or(Ok(None), |v| v.map(Some))
+                    .map_err(|_| ProtocolError::ArrayConversion)?
+                    .map(u16::from_le_bytes),
+                rtcp_interval: video_rtp_param_objs
+                    .get(&RTP_PARAM_TYPES_RTCP_SEND_INTERVAL)
+                    .map(|bytes| bytes.clone().try_into() as Result<[u8; 4], _>)
+                    .map_or(Ok(None), |v| v.map(Some))
+                    .map_err(|_| ProtocolError::ArrayConversion)?
+                    .map(f32::from_le_bytes),
+                max_mtu: video_rtp_param_objs.get(&RTP_PARAM_TYPES_RTCP_SEND_INTERVAL).cloned(),
+            });
+        }
+    }
+
+    // audio
+    if let Some(audio_tlv) = objs.get(&SELECTED_STREAM_CONFIGURATION_TYPES_AUDIO) {
+        let audio_objs = decode(&audio_tlv);
+        let codec = audio_objs
+            .get(&AUDIO_TYPES_CODEC)
+            .ok_or(ProtocolError::MissingProperty)?
+            .clone();
+
+        let audio_codec_param_objs = decode(
+            audio_objs
+                .get(&AUDIO_TYPES_CODEC_PARAM)
+                .ok_or(ProtocolError::MissingProperty)?,
+        );
+        let audio_rtp_param_objs = decode(
+            audio_objs
+                .get(&AUDIO_TYPES_RTP_PARAM)
+                .ok_or(ProtocolError::MissingProperty)?,
+        );
+
+        let comfort_noise = audio_objs
+            .get(&AUDIO_TYPES_COMFORT_NOISE)
+            .ok_or(ProtocolError::MissingProperty)?
+            .clone();
+
+        let channel = audio_codec_param_objs
+            .get(&AUDIO_CODEC_PARAM_TYPES_CHANNEL)
+            .ok_or(ProtocolError::MissingProperty)?
+            .first()
+            .ok_or(ProtocolError::MissingProperty)?
+            .clone();
+        let bitrate = audio_codec_param_objs
+            .get(&AUDIO_CODEC_PARAM_TYPES_BIT_RATE)
+            .ok_or(ProtocolError::MissingProperty)?
+            .first()
+            .ok_or(ProtocolError::MissingProperty)?;
+        let bitrate = *bitrate != 0;
+        let sample_rate = audio_codec_param_objs
+            .get(&AUDIO_CODEC_PARAM_TYPES_SAMPLE_RATE)
+            .ok_or(ProtocolError::MissingProperty)?
+            .first()
+            .ok_or(ProtocolError::MissingProperty)?
+            .clone();
+        let sample_rate = 8 * (1 + sample_rate);
+        let packet_time = audio_codec_param_objs
+            .get(&AUDIO_CODEC_PARAM_TYPES_PACKET_TIME)
+            .ok_or(ProtocolError::MissingProperty)?
+            .first()
+            .ok_or(ProtocolError::MissingProperty)?
+            .clone();
+
+        let ssrc = audio_rtp_param_objs
+            .get(&RTP_PARAM_TYPES_SYNCHRONIZATION_SOURCE)
+            .ok_or(ProtocolError::MissingProperty)?
+            .clone();
+        let ssrc = u32::from_le_bytes(ssrc.clone().try_into().map_err(|_| ProtocolError::ArrayConversion)?);
+        let payload_type = audio_rtp_param_objs
+            .get(&RTP_PARAM_TYPES_PAYLOAD_TYPE)
+            .ok_or(ProtocolError::MissingProperty)?
+            .clone();
+        let max_bitrate = audio_rtp_param_objs
+            .get(&RTP_PARAM_TYPES_MAX_BIT_RATE)
+            .ok_or(ProtocolError::MissingProperty)?;
+        let max_bitrate = u16::from_le_bytes(
+            max_bitrate
+                .clone()
+                .try_into()
+                .map_err(|_| ProtocolError::ArrayConversion)?,
+        );
+        let rtcp_interval = audio_rtp_param_objs
+            .get(&RTP_PARAM_TYPES_RTCP_SEND_INTERVAL)
+            .ok_or(ProtocolError::MissingProperty)?;
+        let rtcp_interval = f32::from_le_bytes(
+            rtcp_interval
+                .clone()
+                .try_into()
+                .map_err(|_| ProtocolError::ArrayConversion)?,
+        );
+        let comfort_payload_type = audio_rtp_param_objs
+            .get(&RTP_PARAM_TYPES_COMFORT_NOISE_PAYLOAD_TYPE)
+            .ok_or(ProtocolError::MissingProperty)?
+            .clone();
+
+        info.audio = Some(StreamAudio {
+            codec,
+            comfort_noise,
+            channel,
+            bitrate,
+            sample_rate,
+            packet_time,
+            ssrc,
+            payload_type,
+            max_bitrate,
+            rtcp_interval,
+            comfort_payload_type,
+        });
+    }
+
+    Ok(info)
+}
+
+pub(crate) fn selected_stream_configuration_request(bytes: &[u8]) -> Result<SelectedStreamRequest, ProtocolError> {
+    let objs = decode(bytes);
+    let session_objs = decode(
+        objs.get(&SELECTED_STREAM_CONFIGURATION_TYPES_SESSION)
+            .ok_or(ProtocolError::MissingProperty)?,
+    );
+
+    let session_id = session_objs
+        .get(&SETUP_TYPES_SESSION_ID)
+        .ok_or(ProtocolError::MissingProperty)?;
+
+    let session_id = Uuid::from_bytes(
+        session_id
+            .clone()
+            .try_into()
+            .map_err(|_| ProtocolError::ArrayConversion)?,
+    );
+
+    let request_type = session_objs
+        .get(&0x02)
+        .ok_or(ProtocolError::MissingProperty)?
+        .first()
+        .ok_or(ProtocolError::MissingProperty)?;
+    let kind = match request_type {
+        0 => SelectedStreamRequestKind::Stop,
+        1 => SelectedStreamRequestKind::Start,
+        4 => SelectedStreamRequestKind::StartAndReconfigure,
+        _ => return Err(ProtocolError::MissingProperty),
+    };
+
+    Ok(SelectedStreamRequest { session_id, kind })
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    pub fn stream_info() {
+        let data = vec![
+            1u8, 21, 2, 1, 1, 1, 16, 159, 74, 88, 188, 175, 8, 79, 248, 128, 222, 231, 61, 225, 39, 125, 40, 2, 52, 1,
+            1, 0, 2, 9, 1, 1, 0, 2, 1, 0, 3, 1, 0, 3, 11, 1, 2, 128, 2, 2, 2, 104, 1, 3, 1, 30, 4, 23, 1, 1, 99, 2, 4,
+            210, 68, 127, 99, 3, 2, 132, 0, 4, 4, 0, 0, 0, 63, 5, 2, 98, 5, 3, 44, 1, 1, 2, 2, 12, 1, 1, 1, 2, 1, 0, 3,
+            1, 1, 4, 1, 30, 3, 22, 1, 1, 110, 2, 4, 82, 196, 23, 55, 3, 2, 24, 0, 4, 4, 0, 0, 160, 64, 6, 1, 13, 4, 1,
+            0,
+        ];
+
+        let info = stream_info_response(&data).unwrap();
+
+        assert_eq!(info.session_id.to_string(), "9f4a58bc-af08-4ff8-80de-e73de1277d28");
+
+        let data2 = vec![
+            1u8, 21, 2, 1, 1, 1, 16, 214, 2, 171, 255, 102, 170, 79, 250, 140, 43, 43, 150, 155, 231, 114, 3, 2, 52, 1,
+            1, 0, 2, 9, 1, 1, 0, 2, 1, 0, 3, 1, 0, 3, 11, 1, 2, 128, 2, 2, 2, 104, 1, 3, 1, 30, 4, 23, 1, 1, 99, 2, 4,
+            186, 145, 247, 16, 3, 2, 132, 0, 4, 4, 0, 0, 0, 63, 5, 2, 98, 5, 3, 44, 1, 1, 2, 2, 12, 1, 1, 1, 2, 1, 0,
+            3, 1, 1, 4, 1, 30, 3, 22, 1, 1, 110, 2, 4, 115, 17, 212, 19, 3, 2, 24, 0, 4, 4, 0, 0, 160, 64, 6, 1, 13, 4,
+            1, 0,
+        ];
+
+        let info = stream_info_response(&data2).unwrap();
+
+        assert!(!info.audio.map(|audio| audio.bitrate).unwrap());
+    }
+
+    #[test]
+    pub fn support_rtp() {
+        let config = supported_rtp_config(true);
+
+        assert_eq!(&config, &[0x02, 0x01, 0x00]);
+    }
+
+    #[test]
+    pub fn audio_stream() {
+        let config = audio_stream_config(json!({
+            "codecs": [
+                {
+                    "type": "AAC-eld",
+                    "samplerate": 16,
+                }
+            ]
+        }));
+
+        assert_eq!(
+            &config,
+            &[
+                0x01, 0x0e, 0x01, 0x01, 0x02, 0x02, 0x09, 0x01, 0x01, 0x01, 0x02, 0x01, 0x00, 0x03, 0x01, 0x01, 0x02,
+                0x01, 0x00
+            ]
+        );
+    }
+
+    #[test]
+    pub fn video_stream() {
+        let config = video_stream_config(json!({
+            "resolutions": [
+                [ 320, 180, 30 ],
+                [ 320, 240, 15 ],
+                [ 320, 240, 30 ],
+                [ 480, 270, 30 ],
+                [ 480, 360, 30 ],
+                [ 640, 360, 30 ],
+                [ 640, 480, 30 ],
+                [ 1280, 720, 30 ],
+                [ 1280, 960, 30 ],
+                [ 1920, 1080, 30 ],
+                [ 1600, 1200, 30 ]
+          ],
+          "codec": {
+              "profiles": [ 0, 1, 2 ],
+              "levels": [ 0, 1, 2 ]
+          }
+        }));
+
+        let expected = b"\x01\xc5\x01\x01\x00\x02\x1d\x01\x01\x00\x00\x00\x01\x01\x01\x00\x00\
+            \x01\x01\x02\x02\x01\x00\x00\x00\x02\x01\x01\x00\x00\x02\x01\x02\x03\x01\x00\x03\x0b\x01\x02\
+            \x40\x01\x02\x02\xb4\x00\x03\x01\x1e\x00\x00\x03\x0b\x01\x02\x40\x01\x02\x02\xf0\x00\x03\x01\
+            \x0f\x00\x00\x03\x0b\x01\x02\x40\x01\x02\x02\xf0\x00\x03\x01\x1e\x00\x00\x03\x0b\x01\x02\xe0\
+            \x01\x02\x02\x0e\x01\x03\x01\x1e\x00\x00\x03\x0b\x01\x02\xe0\x01\x02\x02\x68\x01\x03\x01\x1e\
+            \x00\x00\x03\x0b\x01\x02\x80\x02\x02\x02\x68\x01\x03\x01\x1e\x00\x00\x03\x0b\x01\x02\x80\x02\
+            \x02\x02\xe0\x01\x03\x01\x1e\x00\x00\x03\x0b\x01\x02\x00\x05\x02\x02\xd0\x02\x03\x01\x1e\x00\
+            \x00\x03\x0b\x01\x02\x00\x05\x02\x02\xc0\x03\x03\x01\x1e\x00\x00\x03\x0b\x01\x02\x80\x07\x02\
+            \x02\x38\x04\x03\x01\x1e\x00\x00\x03\x0b\x01\x02\x40\x06\x02\x02\xb0\x04\x03\x01\x1e";
+
+        assert_eq!(&config, expected);
+    }
+
+    #[test]
+    pub fn setup_endpoint() {
+        let data = vec![
+            1u8, 16, 97, 204, 48, 49, 240, 116, 75, 2, 150, 143, 224, 143, 38, 45, 40, 65, 3, 25, 1, 1, 0, 2, 12, 49,
+            57, 50, 46, 49, 54, 56, 46, 50, 46, 53, 50, 3, 2, 149, 192, 4, 2, 80, 238, 4, 37, 2, 16, 8, 255, 34, 115,
+            19, 121, 118, 140, 129, 31, 225, 7, 8, 113, 47, 183, 3, 14, 224, 107, 26, 188, 12, 133, 251, 85, 169, 57,
+            32, 164, 163, 101, 1, 1, 0, 5, 37, 2, 16, 143, 234, 217, 0, 38, 98, 183, 222, 143, 69, 27, 46, 24, 58, 169,
+            193, 3, 14, 210, 110, 127, 168, 239, 73, 194, 105, 156, 195, 164, 211, 59, 231, 1, 1, 0,
+        ];
+
+        let request = setup_endpoint_request(&data).unwrap();
+
+        assert_eq!(
+            request.session_id.to_string(),
+            "61cc3031-f074-4b02-968f-e08f262d2841".to_string()
+        );
+    }
+}

--- a/src/accessory/defined/mod.rs
+++ b/src/accessory/defined/mod.rs
@@ -1,5 +1,7 @@
 /// Bridge accessory definition.
 pub mod bridge;
+/// Camera accessory definition.
+pub mod camera;
 /// Faucet accessory definition.
 pub mod faucet;
 /// Heater-Cooler accessory definition.

--- a/src/characteristic/generated/access_code_control_point.rs
+++ b/src/characteristic/generated/access_code_control_point.rs
@@ -27,13 +27,13 @@ use crate::{
 // TODO - re-check MaximumDataLength
 /// Access Code Control Point characteristic.
 #[derive(Debug, Default, Serialize)]
-pub struct AccessCodeControlPointCharacteristic(Characteristic<Vec<u8>>);
+pub struct AccessCodeControlPointCharacteristic(Characteristic<crate::tlv::Tlv8>);
 
 impl AccessCodeControlPointCharacteristic {
     /// Creates a new Access Code Control Point characteristic.
     pub fn new(id: u64, accessory_id: u64) -> Self {
         #[allow(unused_mut)]
-        let mut c = Self(Characteristic::<Vec<u8>> {
+        let mut c = Self(Characteristic::<crate::tlv::Tlv8> {
             id,
             accessory_id,
             hap_type: HapType::AccessCodeControlPoint,
@@ -156,18 +156,18 @@ impl HapCharacteristicSetup for AccessCodeControlPointCharacteristic {
     }
 }
 
-impl CharacteristicCallbacks<Vec<u8>> for AccessCodeControlPointCharacteristic {
-    fn on_read(&mut self, f: Option<impl OnReadFn<Vec<u8>>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
+impl CharacteristicCallbacks<crate::tlv::Tlv8> for AccessCodeControlPointCharacteristic {
+    fn on_read(&mut self, f: Option<impl OnReadFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
 
-    fn on_update(&mut self, f: Option<impl OnUpdateFn<Vec<u8>>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
+    fn on_update(&mut self, f: Option<impl OnUpdateFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
 }
 
-impl AsyncCharacteristicCallbacks<Vec<u8>> for AccessCodeControlPointCharacteristic {
-    fn on_read_async(&mut self, f: Option<impl OnReadFuture<Vec<u8>>>) {
+impl AsyncCharacteristicCallbacks<crate::tlv::Tlv8> for AccessCodeControlPointCharacteristic {
+    fn on_read_async(&mut self, f: Option<impl OnReadFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_read_async(&mut self.0, f)
     }
 
-    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<Vec<u8>>>) {
+    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_update_async(&mut self.0, f)
     }
 }

--- a/src/characteristic/generated/access_code_supported_configuration.rs
+++ b/src/characteristic/generated/access_code_supported_configuration.rs
@@ -27,13 +27,13 @@ use crate::{
 // TODO - re-check MaximumDataLength
 /// Access Code Supported Configuration characteristic.
 #[derive(Debug, Default, Serialize)]
-pub struct AccessCodeSupportedConfigurationCharacteristic(Characteristic<Vec<u8>>);
+pub struct AccessCodeSupportedConfigurationCharacteristic(Characteristic<crate::tlv::Tlv8>);
 
 impl AccessCodeSupportedConfigurationCharacteristic {
     /// Creates a new Access Code Supported Configuration characteristic.
     pub fn new(id: u64, accessory_id: u64) -> Self {
         #[allow(unused_mut)]
-        let mut c = Self(Characteristic::<Vec<u8>> {
+        let mut c = Self(Characteristic::<crate::tlv::Tlv8> {
             id,
             accessory_id,
             hap_type: HapType::AccessCodeSupportedConfiguration,
@@ -155,18 +155,18 @@ impl HapCharacteristicSetup for AccessCodeSupportedConfigurationCharacteristic {
     }
 }
 
-impl CharacteristicCallbacks<Vec<u8>> for AccessCodeSupportedConfigurationCharacteristic {
-    fn on_read(&mut self, f: Option<impl OnReadFn<Vec<u8>>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
+impl CharacteristicCallbacks<crate::tlv::Tlv8> for AccessCodeSupportedConfigurationCharacteristic {
+    fn on_read(&mut self, f: Option<impl OnReadFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
 
-    fn on_update(&mut self, f: Option<impl OnUpdateFn<Vec<u8>>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
+    fn on_update(&mut self, f: Option<impl OnUpdateFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
 }
 
-impl AsyncCharacteristicCallbacks<Vec<u8>> for AccessCodeSupportedConfigurationCharacteristic {
-    fn on_read_async(&mut self, f: Option<impl OnReadFuture<Vec<u8>>>) {
+impl AsyncCharacteristicCallbacks<crate::tlv::Tlv8> for AccessCodeSupportedConfigurationCharacteristic {
+    fn on_read_async(&mut self, f: Option<impl OnReadFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_read_async(&mut self.0, f)
     }
 
-    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<Vec<u8>>>) {
+    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_update_async(&mut self.0, f)
     }
 }

--- a/src/characteristic/generated/application_matching_identifier.rs
+++ b/src/characteristic/generated/application_matching_identifier.rs
@@ -27,13 +27,13 @@ use crate::{
 // TODO - re-check MaximumDataLength
 /// Application Matching Identifier characteristic.
 #[derive(Debug, Default, Serialize)]
-pub struct ApplicationMatchingIdentifierCharacteristic(Characteristic<Vec<u8>>);
+pub struct ApplicationMatchingIdentifierCharacteristic(Characteristic<crate::tlv::Tlv8>);
 
 impl ApplicationMatchingIdentifierCharacteristic {
     /// Creates a new Application Matching Identifier characteristic.
     pub fn new(id: u64, accessory_id: u64) -> Self {
         #[allow(unused_mut)]
-        let mut c = Self(Characteristic::<Vec<u8>> {
+        let mut c = Self(Characteristic::<crate::tlv::Tlv8> {
             id,
             accessory_id,
             hap_type: HapType::ApplicationMatchingIdentifier,
@@ -155,18 +155,18 @@ impl HapCharacteristicSetup for ApplicationMatchingIdentifierCharacteristic {
     }
 }
 
-impl CharacteristicCallbacks<Vec<u8>> for ApplicationMatchingIdentifierCharacteristic {
-    fn on_read(&mut self, f: Option<impl OnReadFn<Vec<u8>>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
+impl CharacteristicCallbacks<crate::tlv::Tlv8> for ApplicationMatchingIdentifierCharacteristic {
+    fn on_read(&mut self, f: Option<impl OnReadFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
 
-    fn on_update(&mut self, f: Option<impl OnUpdateFn<Vec<u8>>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
+    fn on_update(&mut self, f: Option<impl OnUpdateFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
 }
 
-impl AsyncCharacteristicCallbacks<Vec<u8>> for ApplicationMatchingIdentifierCharacteristic {
-    fn on_read_async(&mut self, f: Option<impl OnReadFuture<Vec<u8>>>) {
+impl AsyncCharacteristicCallbacks<crate::tlv::Tlv8> for ApplicationMatchingIdentifierCharacteristic {
+    fn on_read_async(&mut self, f: Option<impl OnReadFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_read_async(&mut self.0, f)
     }
 
-    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<Vec<u8>>>) {
+    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_update_async(&mut self.0, f)
     }
 }

--- a/src/characteristic/generated/button_event.rs
+++ b/src/characteristic/generated/button_event.rs
@@ -27,13 +27,13 @@ use crate::{
 // TODO - re-check MaximumDataLength
 /// Button Event characteristic.
 #[derive(Debug, Default, Serialize)]
-pub struct ButtonEventCharacteristic(Characteristic<Vec<u8>>);
+pub struct ButtonEventCharacteristic(Characteristic<crate::tlv::Tlv8>);
 
 impl ButtonEventCharacteristic {
     /// Creates a new Button Event characteristic.
     pub fn new(id: u64, accessory_id: u64) -> Self {
         #[allow(unused_mut)]
-        let mut c = Self(Characteristic::<Vec<u8>> {
+        let mut c = Self(Characteristic::<crate::tlv::Tlv8> {
             id,
             accessory_id,
             hap_type: HapType::ButtonEvent,
@@ -156,18 +156,18 @@ impl HapCharacteristicSetup for ButtonEventCharacteristic {
     }
 }
 
-impl CharacteristicCallbacks<Vec<u8>> for ButtonEventCharacteristic {
-    fn on_read(&mut self, f: Option<impl OnReadFn<Vec<u8>>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
+impl CharacteristicCallbacks<crate::tlv::Tlv8> for ButtonEventCharacteristic {
+    fn on_read(&mut self, f: Option<impl OnReadFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
 
-    fn on_update(&mut self, f: Option<impl OnUpdateFn<Vec<u8>>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
+    fn on_update(&mut self, f: Option<impl OnUpdateFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
 }
 
-impl AsyncCharacteristicCallbacks<Vec<u8>> for ButtonEventCharacteristic {
-    fn on_read_async(&mut self, f: Option<impl OnReadFuture<Vec<u8>>>) {
+impl AsyncCharacteristicCallbacks<crate::tlv::Tlv8> for ButtonEventCharacteristic {
+    fn on_read_async(&mut self, f: Option<impl OnReadFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_read_async(&mut self.0, f)
     }
 
-    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<Vec<u8>>>) {
+    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_update_async(&mut self.0, f)
     }
 }

--- a/src/characteristic/generated/characteristic_value_transition_control.rs
+++ b/src/characteristic/generated/characteristic_value_transition_control.rs
@@ -27,13 +27,13 @@ use crate::{
 // TODO - re-check MaximumDataLength
 /// Characteristic Value Transition Control characteristic.
 #[derive(Debug, Default, Serialize)]
-pub struct CharacteristicValueTransitionControlCharacteristic(Characteristic<Vec<u8>>);
+pub struct CharacteristicValueTransitionControlCharacteristic(Characteristic<crate::tlv::Tlv8>);
 
 impl CharacteristicValueTransitionControlCharacteristic {
     /// Creates a new Characteristic Value Transition Control characteristic.
     pub fn new(id: u64, accessory_id: u64) -> Self {
         #[allow(unused_mut)]
-        let mut c = Self(Characteristic::<Vec<u8>> {
+        let mut c = Self(Characteristic::<crate::tlv::Tlv8> {
             id,
             accessory_id,
             hap_type: HapType::CharacteristicValueTransitionControl,
@@ -156,18 +156,18 @@ impl HapCharacteristicSetup for CharacteristicValueTransitionControlCharacterist
     }
 }
 
-impl CharacteristicCallbacks<Vec<u8>> for CharacteristicValueTransitionControlCharacteristic {
-    fn on_read(&mut self, f: Option<impl OnReadFn<Vec<u8>>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
+impl CharacteristicCallbacks<crate::tlv::Tlv8> for CharacteristicValueTransitionControlCharacteristic {
+    fn on_read(&mut self, f: Option<impl OnReadFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
 
-    fn on_update(&mut self, f: Option<impl OnUpdateFn<Vec<u8>>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
+    fn on_update(&mut self, f: Option<impl OnUpdateFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
 }
 
-impl AsyncCharacteristicCallbacks<Vec<u8>> for CharacteristicValueTransitionControlCharacteristic {
-    fn on_read_async(&mut self, f: Option<impl OnReadFuture<Vec<u8>>>) {
+impl AsyncCharacteristicCallbacks<crate::tlv::Tlv8> for CharacteristicValueTransitionControlCharacteristic {
+    fn on_read_async(&mut self, f: Option<impl OnReadFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_read_async(&mut self.0, f)
     }
 
-    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<Vec<u8>>>) {
+    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_update_async(&mut self.0, f)
     }
 }

--- a/src/characteristic/generated/cloud_relay_control_point.rs
+++ b/src/characteristic/generated/cloud_relay_control_point.rs
@@ -27,13 +27,13 @@ use crate::{
 // TODO - re-check MaximumDataLength
 /// Cloud Relay Control Point characteristic.
 #[derive(Debug, Default, Serialize)]
-pub struct CloudRelayControlPointCharacteristic(Characteristic<Vec<u8>>);
+pub struct CloudRelayControlPointCharacteristic(Characteristic<crate::tlv::Tlv8>);
 
 impl CloudRelayControlPointCharacteristic {
     /// Creates a new Cloud Relay Control Point characteristic.
     pub fn new(id: u64, accessory_id: u64) -> Self {
         #[allow(unused_mut)]
-        let mut c = Self(Characteristic::<Vec<u8>> {
+        let mut c = Self(Characteristic::<crate::tlv::Tlv8> {
             id,
             accessory_id,
             hap_type: HapType::CloudRelayControlPoint,
@@ -157,18 +157,18 @@ impl HapCharacteristicSetup for CloudRelayControlPointCharacteristic {
     }
 }
 
-impl CharacteristicCallbacks<Vec<u8>> for CloudRelayControlPointCharacteristic {
-    fn on_read(&mut self, f: Option<impl OnReadFn<Vec<u8>>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
+impl CharacteristicCallbacks<crate::tlv::Tlv8> for CloudRelayControlPointCharacteristic {
+    fn on_read(&mut self, f: Option<impl OnReadFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
 
-    fn on_update(&mut self, f: Option<impl OnUpdateFn<Vec<u8>>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
+    fn on_update(&mut self, f: Option<impl OnUpdateFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
 }
 
-impl AsyncCharacteristicCallbacks<Vec<u8>> for CloudRelayControlPointCharacteristic {
-    fn on_read_async(&mut self, f: Option<impl OnReadFuture<Vec<u8>>>) {
+impl AsyncCharacteristicCallbacks<crate::tlv::Tlv8> for CloudRelayControlPointCharacteristic {
+    fn on_read_async(&mut self, f: Option<impl OnReadFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_read_async(&mut self.0, f)
     }
 
-    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<Vec<u8>>>) {
+    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_update_async(&mut self.0, f)
     }
 }

--- a/src/characteristic/generated/data_stream_hap_transport.rs
+++ b/src/characteristic/generated/data_stream_hap_transport.rs
@@ -27,13 +27,13 @@ use crate::{
 // TODO - re-check MaximumDataLength
 /// Data Stream HAP Transport characteristic.
 #[derive(Debug, Default, Serialize)]
-pub struct DataStreamHapTransportCharacteristic(Characteristic<Vec<u8>>);
+pub struct DataStreamHapTransportCharacteristic(Characteristic<crate::tlv::Tlv8>);
 
 impl DataStreamHapTransportCharacteristic {
     /// Creates a new Data Stream HAP Transport characteristic.
     pub fn new(id: u64, accessory_id: u64) -> Self {
         #[allow(unused_mut)]
-        let mut c = Self(Characteristic::<Vec<u8>> {
+        let mut c = Self(Characteristic::<crate::tlv::Tlv8> {
             id,
             accessory_id,
             hap_type: HapType::DataStreamHapTransport,
@@ -156,18 +156,18 @@ impl HapCharacteristicSetup for DataStreamHapTransportCharacteristic {
     }
 }
 
-impl CharacteristicCallbacks<Vec<u8>> for DataStreamHapTransportCharacteristic {
-    fn on_read(&mut self, f: Option<impl OnReadFn<Vec<u8>>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
+impl CharacteristicCallbacks<crate::tlv::Tlv8> for DataStreamHapTransportCharacteristic {
+    fn on_read(&mut self, f: Option<impl OnReadFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
 
-    fn on_update(&mut self, f: Option<impl OnUpdateFn<Vec<u8>>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
+    fn on_update(&mut self, f: Option<impl OnUpdateFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
 }
 
-impl AsyncCharacteristicCallbacks<Vec<u8>> for DataStreamHapTransportCharacteristic {
-    fn on_read_async(&mut self, f: Option<impl OnReadFuture<Vec<u8>>>) {
+impl AsyncCharacteristicCallbacks<crate::tlv::Tlv8> for DataStreamHapTransportCharacteristic {
+    fn on_read_async(&mut self, f: Option<impl OnReadFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_read_async(&mut self.0, f)
     }
 
-    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<Vec<u8>>>) {
+    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_update_async(&mut self.0, f)
     }
 }

--- a/src/characteristic/generated/data_stream_hap_transport_interrupt.rs
+++ b/src/characteristic/generated/data_stream_hap_transport_interrupt.rs
@@ -27,13 +27,13 @@ use crate::{
 // TODO - re-check MaximumDataLength
 /// Data Stream HAP Transport Interrupt characteristic.
 #[derive(Debug, Default, Serialize)]
-pub struct DataStreamHapTransportInterruptCharacteristic(Characteristic<Vec<u8>>);
+pub struct DataStreamHapTransportInterruptCharacteristic(Characteristic<crate::tlv::Tlv8>);
 
 impl DataStreamHapTransportInterruptCharacteristic {
     /// Creates a new Data Stream HAP Transport Interrupt characteristic.
     pub fn new(id: u64, accessory_id: u64) -> Self {
         #[allow(unused_mut)]
-        let mut c = Self(Characteristic::<Vec<u8>> {
+        let mut c = Self(Characteristic::<crate::tlv::Tlv8> {
             id,
             accessory_id,
             hap_type: HapType::DataStreamHapTransportInterrupt,
@@ -156,18 +156,18 @@ impl HapCharacteristicSetup for DataStreamHapTransportInterruptCharacteristic {
     }
 }
 
-impl CharacteristicCallbacks<Vec<u8>> for DataStreamHapTransportInterruptCharacteristic {
-    fn on_read(&mut self, f: Option<impl OnReadFn<Vec<u8>>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
+impl CharacteristicCallbacks<crate::tlv::Tlv8> for DataStreamHapTransportInterruptCharacteristic {
+    fn on_read(&mut self, f: Option<impl OnReadFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
 
-    fn on_update(&mut self, f: Option<impl OnUpdateFn<Vec<u8>>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
+    fn on_update(&mut self, f: Option<impl OnUpdateFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
 }
 
-impl AsyncCharacteristicCallbacks<Vec<u8>> for DataStreamHapTransportInterruptCharacteristic {
-    fn on_read_async(&mut self, f: Option<impl OnReadFuture<Vec<u8>>>) {
+impl AsyncCharacteristicCallbacks<crate::tlv::Tlv8> for DataStreamHapTransportInterruptCharacteristic {
+    fn on_read_async(&mut self, f: Option<impl OnReadFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_read_async(&mut self.0, f)
     }
 
-    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<Vec<u8>>>) {
+    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_update_async(&mut self.0, f)
     }
 }

--- a/src/characteristic/generated/display_order.rs
+++ b/src/characteristic/generated/display_order.rs
@@ -27,13 +27,13 @@ use crate::{
 // TODO - re-check MaximumDataLength
 /// Display Order characteristic.
 #[derive(Debug, Default, Serialize)]
-pub struct DisplayOrderCharacteristic(Characteristic<Vec<u8>>);
+pub struct DisplayOrderCharacteristic(Characteristic<crate::tlv::Tlv8>);
 
 impl DisplayOrderCharacteristic {
     /// Creates a new Display Order characteristic.
     pub fn new(id: u64, accessory_id: u64) -> Self {
         #[allow(unused_mut)]
-        let mut c = Self(Characteristic::<Vec<u8>> {
+        let mut c = Self(Characteristic::<crate::tlv::Tlv8> {
             id,
             accessory_id,
             hap_type: HapType::DisplayOrder,
@@ -156,18 +156,18 @@ impl HapCharacteristicSetup for DisplayOrderCharacteristic {
     }
 }
 
-impl CharacteristicCallbacks<Vec<u8>> for DisplayOrderCharacteristic {
-    fn on_read(&mut self, f: Option<impl OnReadFn<Vec<u8>>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
+impl CharacteristicCallbacks<crate::tlv::Tlv8> for DisplayOrderCharacteristic {
+    fn on_read(&mut self, f: Option<impl OnReadFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
 
-    fn on_update(&mut self, f: Option<impl OnUpdateFn<Vec<u8>>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
+    fn on_update(&mut self, f: Option<impl OnUpdateFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
 }
 
-impl AsyncCharacteristicCallbacks<Vec<u8>> for DisplayOrderCharacteristic {
-    fn on_read_async(&mut self, f: Option<impl OnReadFuture<Vec<u8>>>) {
+impl AsyncCharacteristicCallbacks<crate::tlv::Tlv8> for DisplayOrderCharacteristic {
+    fn on_read_async(&mut self, f: Option<impl OnReadFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_read_async(&mut self.0, f)
     }
 
-    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<Vec<u8>>>) {
+    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_update_async(&mut self.0, f)
     }
 }

--- a/src/characteristic/generated/firmware_update_readiness.rs
+++ b/src/characteristic/generated/firmware_update_readiness.rs
@@ -27,13 +27,13 @@ use crate::{
 // TODO - re-check MaximumDataLength
 /// Firmware Update Readiness characteristic.
 #[derive(Debug, Default, Serialize)]
-pub struct FirmwareUpdateReadinessCharacteristic(Characteristic<Vec<u8>>);
+pub struct FirmwareUpdateReadinessCharacteristic(Characteristic<crate::tlv::Tlv8>);
 
 impl FirmwareUpdateReadinessCharacteristic {
     /// Creates a new Firmware Update Readiness characteristic.
     pub fn new(id: u64, accessory_id: u64) -> Self {
         #[allow(unused_mut)]
-        let mut c = Self(Characteristic::<Vec<u8>> {
+        let mut c = Self(Characteristic::<crate::tlv::Tlv8> {
             id,
             accessory_id,
             hap_type: HapType::FirmwareUpdateReadiness,
@@ -156,18 +156,18 @@ impl HapCharacteristicSetup for FirmwareUpdateReadinessCharacteristic {
     }
 }
 
-impl CharacteristicCallbacks<Vec<u8>> for FirmwareUpdateReadinessCharacteristic {
-    fn on_read(&mut self, f: Option<impl OnReadFn<Vec<u8>>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
+impl CharacteristicCallbacks<crate::tlv::Tlv8> for FirmwareUpdateReadinessCharacteristic {
+    fn on_read(&mut self, f: Option<impl OnReadFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
 
-    fn on_update(&mut self, f: Option<impl OnUpdateFn<Vec<u8>>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
+    fn on_update(&mut self, f: Option<impl OnUpdateFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
 }
 
-impl AsyncCharacteristicCallbacks<Vec<u8>> for FirmwareUpdateReadinessCharacteristic {
-    fn on_read_async(&mut self, f: Option<impl OnReadFuture<Vec<u8>>>) {
+impl AsyncCharacteristicCallbacks<crate::tlv::Tlv8> for FirmwareUpdateReadinessCharacteristic {
+    fn on_read_async(&mut self, f: Option<impl OnReadFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_read_async(&mut self.0, f)
     }
 
-    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<Vec<u8>>>) {
+    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_update_async(&mut self.0, f)
     }
 }

--- a/src/characteristic/generated/firmware_update_status.rs
+++ b/src/characteristic/generated/firmware_update_status.rs
@@ -27,13 +27,13 @@ use crate::{
 // TODO - re-check MaximumDataLength
 /// Firmware Update Status characteristic.
 #[derive(Debug, Default, Serialize)]
-pub struct FirmwareUpdateStatusCharacteristic(Characteristic<Vec<u8>>);
+pub struct FirmwareUpdateStatusCharacteristic(Characteristic<crate::tlv::Tlv8>);
 
 impl FirmwareUpdateStatusCharacteristic {
     /// Creates a new Firmware Update Status characteristic.
     pub fn new(id: u64, accessory_id: u64) -> Self {
         #[allow(unused_mut)]
-        let mut c = Self(Characteristic::<Vec<u8>> {
+        let mut c = Self(Characteristic::<crate::tlv::Tlv8> {
             id,
             accessory_id,
             hap_type: HapType::FirmwareUpdateStatus,
@@ -156,18 +156,18 @@ impl HapCharacteristicSetup for FirmwareUpdateStatusCharacteristic {
     }
 }
 
-impl CharacteristicCallbacks<Vec<u8>> for FirmwareUpdateStatusCharacteristic {
-    fn on_read(&mut self, f: Option<impl OnReadFn<Vec<u8>>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
+impl CharacteristicCallbacks<crate::tlv::Tlv8> for FirmwareUpdateStatusCharacteristic {
+    fn on_read(&mut self, f: Option<impl OnReadFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
 
-    fn on_update(&mut self, f: Option<impl OnUpdateFn<Vec<u8>>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
+    fn on_update(&mut self, f: Option<impl OnUpdateFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
 }
 
-impl AsyncCharacteristicCallbacks<Vec<u8>> for FirmwareUpdateStatusCharacteristic {
-    fn on_read_async(&mut self, f: Option<impl OnReadFuture<Vec<u8>>>) {
+impl AsyncCharacteristicCallbacks<crate::tlv::Tlv8> for FirmwareUpdateStatusCharacteristic {
+    fn on_read_async(&mut self, f: Option<impl OnReadFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_read_async(&mut self.0, f)
     }
 
-    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<Vec<u8>>>) {
+    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_update_async(&mut self.0, f)
     }
 }

--- a/src/characteristic/generated/hardware_finish.rs
+++ b/src/characteristic/generated/hardware_finish.rs
@@ -27,13 +27,13 @@ use crate::{
 // TODO - re-check MaximumDataLength
 /// Hardware Finish characteristic.
 #[derive(Debug, Default, Serialize)]
-pub struct HardwareFinishCharacteristic(Characteristic<Vec<u8>>);
+pub struct HardwareFinishCharacteristic(Characteristic<crate::tlv::Tlv8>);
 
 impl HardwareFinishCharacteristic {
     /// Creates a new Hardware Finish characteristic.
     pub fn new(id: u64, accessory_id: u64) -> Self {
         #[allow(unused_mut)]
-        let mut c = Self(Characteristic::<Vec<u8>> {
+        let mut c = Self(Characteristic::<crate::tlv::Tlv8> {
             id,
             accessory_id,
             hap_type: HapType::HardwareFinish,
@@ -155,18 +155,18 @@ impl HapCharacteristicSetup for HardwareFinishCharacteristic {
     }
 }
 
-impl CharacteristicCallbacks<Vec<u8>> for HardwareFinishCharacteristic {
-    fn on_read(&mut self, f: Option<impl OnReadFn<Vec<u8>>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
+impl CharacteristicCallbacks<crate::tlv::Tlv8> for HardwareFinishCharacteristic {
+    fn on_read(&mut self, f: Option<impl OnReadFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
 
-    fn on_update(&mut self, f: Option<impl OnUpdateFn<Vec<u8>>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
+    fn on_update(&mut self, f: Option<impl OnUpdateFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
 }
 
-impl AsyncCharacteristicCallbacks<Vec<u8>> for HardwareFinishCharacteristic {
-    fn on_read_async(&mut self, f: Option<impl OnReadFuture<Vec<u8>>>) {
+impl AsyncCharacteristicCallbacks<crate::tlv::Tlv8> for HardwareFinishCharacteristic {
+    fn on_read_async(&mut self, f: Option<impl OnReadFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_read_async(&mut self.0, f)
     }
 
-    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<Vec<u8>>>) {
+    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_update_async(&mut self.0, f)
     }
 }

--- a/src/characteristic/generated/list_pairings.rs
+++ b/src/characteristic/generated/list_pairings.rs
@@ -27,13 +27,13 @@ use crate::{
 // TODO - re-check MaximumDataLength
 /// List Pairings characteristic.
 #[derive(Debug, Default, Serialize)]
-pub struct ListPairingsCharacteristic(Characteristic<Vec<u8>>);
+pub struct ListPairingsCharacteristic(Characteristic<crate::tlv::Tlv8>);
 
 impl ListPairingsCharacteristic {
     /// Creates a new List Pairings characteristic.
     pub fn new(id: u64, accessory_id: u64) -> Self {
         #[allow(unused_mut)]
-        let mut c = Self(Characteristic::<Vec<u8>> {
+        let mut c = Self(Characteristic::<crate::tlv::Tlv8> {
             id,
             accessory_id,
             hap_type: HapType::ListPairings,
@@ -156,18 +156,18 @@ impl HapCharacteristicSetup for ListPairingsCharacteristic {
     }
 }
 
-impl CharacteristicCallbacks<Vec<u8>> for ListPairingsCharacteristic {
-    fn on_read(&mut self, f: Option<impl OnReadFn<Vec<u8>>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
+impl CharacteristicCallbacks<crate::tlv::Tlv8> for ListPairingsCharacteristic {
+    fn on_read(&mut self, f: Option<impl OnReadFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
 
-    fn on_update(&mut self, f: Option<impl OnUpdateFn<Vec<u8>>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
+    fn on_update(&mut self, f: Option<impl OnUpdateFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
 }
 
-impl AsyncCharacteristicCallbacks<Vec<u8>> for ListPairingsCharacteristic {
-    fn on_read_async(&mut self, f: Option<impl OnReadFuture<Vec<u8>>>) {
+impl AsyncCharacteristicCallbacks<crate::tlv::Tlv8> for ListPairingsCharacteristic {
+    fn on_read_async(&mut self, f: Option<impl OnReadFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_read_async(&mut self.0, f)
     }
 
-    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<Vec<u8>>>) {
+    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_update_async(&mut self.0, f)
     }
 }

--- a/src/characteristic/generated/lock_control_point.rs
+++ b/src/characteristic/generated/lock_control_point.rs
@@ -27,13 +27,13 @@ use crate::{
 // TODO - re-check MaximumDataLength
 /// Lock Control Point characteristic.
 #[derive(Debug, Default, Serialize)]
-pub struct LockControlPointCharacteristic(Characteristic<Vec<u8>>);
+pub struct LockControlPointCharacteristic(Characteristic<crate::tlv::Tlv8>);
 
 impl LockControlPointCharacteristic {
     /// Creates a new Lock Control Point characteristic.
     pub fn new(id: u64, accessory_id: u64) -> Self {
         #[allow(unused_mut)]
-        let mut c = Self(Characteristic::<Vec<u8>> {
+        let mut c = Self(Characteristic::<crate::tlv::Tlv8> {
             id,
             accessory_id,
             hap_type: HapType::LockControlPoint,
@@ -155,18 +155,18 @@ impl HapCharacteristicSetup for LockControlPointCharacteristic {
     }
 }
 
-impl CharacteristicCallbacks<Vec<u8>> for LockControlPointCharacteristic {
-    fn on_read(&mut self, f: Option<impl OnReadFn<Vec<u8>>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
+impl CharacteristicCallbacks<crate::tlv::Tlv8> for LockControlPointCharacteristic {
+    fn on_read(&mut self, f: Option<impl OnReadFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
 
-    fn on_update(&mut self, f: Option<impl OnUpdateFn<Vec<u8>>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
+    fn on_update(&mut self, f: Option<impl OnUpdateFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
 }
 
-impl AsyncCharacteristicCallbacks<Vec<u8>> for LockControlPointCharacteristic {
-    fn on_read_async(&mut self, f: Option<impl OnReadFuture<Vec<u8>>>) {
+impl AsyncCharacteristicCallbacks<crate::tlv::Tlv8> for LockControlPointCharacteristic {
+    fn on_read_async(&mut self, f: Option<impl OnReadFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_read_async(&mut self.0, f)
     }
 
-    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<Vec<u8>>>) {
+    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_update_async(&mut self.0, f)
     }
 }

--- a/src/characteristic/generated/logs.rs
+++ b/src/characteristic/generated/logs.rs
@@ -27,13 +27,13 @@ use crate::{
 // TODO - re-check MaximumDataLength
 /// Logs characteristic.
 #[derive(Debug, Default, Serialize)]
-pub struct LogsCharacteristic(Characteristic<Vec<u8>>);
+pub struct LogsCharacteristic(Characteristic<crate::tlv::Tlv8>);
 
 impl LogsCharacteristic {
     /// Creates a new Logs characteristic.
     pub fn new(id: u64, accessory_id: u64) -> Self {
         #[allow(unused_mut)]
-        let mut c = Self(Characteristic::<Vec<u8>> {
+        let mut c = Self(Characteristic::<crate::tlv::Tlv8> {
             id,
             accessory_id,
             hap_type: HapType::Logs,
@@ -156,18 +156,18 @@ impl HapCharacteristicSetup for LogsCharacteristic {
     }
 }
 
-impl CharacteristicCallbacks<Vec<u8>> for LogsCharacteristic {
-    fn on_read(&mut self, f: Option<impl OnReadFn<Vec<u8>>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
+impl CharacteristicCallbacks<crate::tlv::Tlv8> for LogsCharacteristic {
+    fn on_read(&mut self, f: Option<impl OnReadFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
 
-    fn on_update(&mut self, f: Option<impl OnUpdateFn<Vec<u8>>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
+    fn on_update(&mut self, f: Option<impl OnUpdateFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
 }
 
-impl AsyncCharacteristicCallbacks<Vec<u8>> for LogsCharacteristic {
-    fn on_read_async(&mut self, f: Option<impl OnReadFuture<Vec<u8>>>) {
+impl AsyncCharacteristicCallbacks<crate::tlv::Tlv8> for LogsCharacteristic {
+    fn on_read_async(&mut self, f: Option<impl OnReadFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_read_async(&mut self.0, f)
     }
 
-    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<Vec<u8>>>) {
+    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_update_async(&mut self.0, f)
     }
 }

--- a/src/characteristic/generated/network_access_violation_control.rs
+++ b/src/characteristic/generated/network_access_violation_control.rs
@@ -27,13 +27,13 @@ use crate::{
 // TODO - re-check MaximumDataLength
 /// Network Access Violation Control characteristic.
 #[derive(Debug, Default, Serialize)]
-pub struct NetworkAccessViolationControlCharacteristic(Characteristic<Vec<u8>>);
+pub struct NetworkAccessViolationControlCharacteristic(Characteristic<crate::tlv::Tlv8>);
 
 impl NetworkAccessViolationControlCharacteristic {
     /// Creates a new Network Access Violation Control characteristic.
     pub fn new(id: u64, accessory_id: u64) -> Self {
         #[allow(unused_mut)]
-        let mut c = Self(Characteristic::<Vec<u8>> {
+        let mut c = Self(Characteristic::<crate::tlv::Tlv8> {
             id,
             accessory_id,
             hap_type: HapType::NetworkAccessViolationControl,
@@ -159,18 +159,18 @@ impl HapCharacteristicSetup for NetworkAccessViolationControlCharacteristic {
     }
 }
 
-impl CharacteristicCallbacks<Vec<u8>> for NetworkAccessViolationControlCharacteristic {
-    fn on_read(&mut self, f: Option<impl OnReadFn<Vec<u8>>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
+impl CharacteristicCallbacks<crate::tlv::Tlv8> for NetworkAccessViolationControlCharacteristic {
+    fn on_read(&mut self, f: Option<impl OnReadFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
 
-    fn on_update(&mut self, f: Option<impl OnUpdateFn<Vec<u8>>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
+    fn on_update(&mut self, f: Option<impl OnUpdateFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
 }
 
-impl AsyncCharacteristicCallbacks<Vec<u8>> for NetworkAccessViolationControlCharacteristic {
-    fn on_read_async(&mut self, f: Option<impl OnReadFuture<Vec<u8>>>) {
+impl AsyncCharacteristicCallbacks<crate::tlv::Tlv8> for NetworkAccessViolationControlCharacteristic {
+    fn on_read_async(&mut self, f: Option<impl OnReadFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_read_async(&mut self.0, f)
     }
 
-    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<Vec<u8>>>) {
+    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_update_async(&mut self.0, f)
     }
 }

--- a/src/characteristic/generated/network_client_control.rs
+++ b/src/characteristic/generated/network_client_control.rs
@@ -27,13 +27,13 @@ use crate::{
 // TODO - re-check MaximumDataLength
 /// Network Client Control characteristic.
 #[derive(Debug, Default, Serialize)]
-pub struct NetworkClientControlCharacteristic(Characteristic<Vec<u8>>);
+pub struct NetworkClientControlCharacteristic(Characteristic<crate::tlv::Tlv8>);
 
 impl NetworkClientControlCharacteristic {
     /// Creates a new Network Client Control characteristic.
     pub fn new(id: u64, accessory_id: u64) -> Self {
         #[allow(unused_mut)]
-        let mut c = Self(Characteristic::<Vec<u8>> {
+        let mut c = Self(Characteristic::<crate::tlv::Tlv8> {
             id,
             accessory_id,
             hap_type: HapType::NetworkClientControl,
@@ -159,18 +159,18 @@ impl HapCharacteristicSetup for NetworkClientControlCharacteristic {
     }
 }
 
-impl CharacteristicCallbacks<Vec<u8>> for NetworkClientControlCharacteristic {
-    fn on_read(&mut self, f: Option<impl OnReadFn<Vec<u8>>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
+impl CharacteristicCallbacks<crate::tlv::Tlv8> for NetworkClientControlCharacteristic {
+    fn on_read(&mut self, f: Option<impl OnReadFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
 
-    fn on_update(&mut self, f: Option<impl OnUpdateFn<Vec<u8>>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
+    fn on_update(&mut self, f: Option<impl OnUpdateFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
 }
 
-impl AsyncCharacteristicCallbacks<Vec<u8>> for NetworkClientControlCharacteristic {
-    fn on_read_async(&mut self, f: Option<impl OnReadFuture<Vec<u8>>>) {
+impl AsyncCharacteristicCallbacks<crate::tlv::Tlv8> for NetworkClientControlCharacteristic {
+    fn on_read_async(&mut self, f: Option<impl OnReadFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_read_async(&mut self.0, f)
     }
 
-    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<Vec<u8>>>) {
+    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_update_async(&mut self.0, f)
     }
 }

--- a/src/characteristic/generated/network_client_status_control.rs
+++ b/src/characteristic/generated/network_client_status_control.rs
@@ -27,13 +27,13 @@ use crate::{
 // TODO - re-check MaximumDataLength
 /// Network Client Status Control characteristic.
 #[derive(Debug, Default, Serialize)]
-pub struct NetworkClientStatusControlCharacteristic(Characteristic<Vec<u8>>);
+pub struct NetworkClientStatusControlCharacteristic(Characteristic<crate::tlv::Tlv8>);
 
 impl NetworkClientStatusControlCharacteristic {
     /// Creates a new Network Client Status Control characteristic.
     pub fn new(id: u64, accessory_id: u64) -> Self {
         #[allow(unused_mut)]
-        let mut c = Self(Characteristic::<Vec<u8>> {
+        let mut c = Self(Characteristic::<crate::tlv::Tlv8> {
             id,
             accessory_id,
             hap_type: HapType::NetworkClientStatusControl,
@@ -157,18 +157,18 @@ impl HapCharacteristicSetup for NetworkClientStatusControlCharacteristic {
     }
 }
 
-impl CharacteristicCallbacks<Vec<u8>> for NetworkClientStatusControlCharacteristic {
-    fn on_read(&mut self, f: Option<impl OnReadFn<Vec<u8>>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
+impl CharacteristicCallbacks<crate::tlv::Tlv8> for NetworkClientStatusControlCharacteristic {
+    fn on_read(&mut self, f: Option<impl OnReadFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
 
-    fn on_update(&mut self, f: Option<impl OnUpdateFn<Vec<u8>>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
+    fn on_update(&mut self, f: Option<impl OnUpdateFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
 }
 
-impl AsyncCharacteristicCallbacks<Vec<u8>> for NetworkClientStatusControlCharacteristic {
-    fn on_read_async(&mut self, f: Option<impl OnReadFuture<Vec<u8>>>) {
+impl AsyncCharacteristicCallbacks<crate::tlv::Tlv8> for NetworkClientStatusControlCharacteristic {
+    fn on_read_async(&mut self, f: Option<impl OnReadFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_read_async(&mut self.0, f)
     }
 
-    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<Vec<u8>>>) {
+    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_update_async(&mut self.0, f)
     }
 }

--- a/src/characteristic/generated/nfc_access_control_point.rs
+++ b/src/characteristic/generated/nfc_access_control_point.rs
@@ -27,13 +27,13 @@ use crate::{
 // TODO - re-check MaximumDataLength
 /// NFC Access Control Point characteristic.
 #[derive(Debug, Default, Serialize)]
-pub struct NfcAccessControlPointCharacteristic(Characteristic<Vec<u8>>);
+pub struct NfcAccessControlPointCharacteristic(Characteristic<crate::tlv::Tlv8>);
 
 impl NfcAccessControlPointCharacteristic {
     /// Creates a new NFC Access Control Point characteristic.
     pub fn new(id: u64, accessory_id: u64) -> Self {
         #[allow(unused_mut)]
-        let mut c = Self(Characteristic::<Vec<u8>> {
+        let mut c = Self(Characteristic::<crate::tlv::Tlv8> {
             id,
             accessory_id,
             hap_type: HapType::NfcAccessControlPoint,
@@ -156,18 +156,18 @@ impl HapCharacteristicSetup for NfcAccessControlPointCharacteristic {
     }
 }
 
-impl CharacteristicCallbacks<Vec<u8>> for NfcAccessControlPointCharacteristic {
-    fn on_read(&mut self, f: Option<impl OnReadFn<Vec<u8>>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
+impl CharacteristicCallbacks<crate::tlv::Tlv8> for NfcAccessControlPointCharacteristic {
+    fn on_read(&mut self, f: Option<impl OnReadFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
 
-    fn on_update(&mut self, f: Option<impl OnUpdateFn<Vec<u8>>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
+    fn on_update(&mut self, f: Option<impl OnUpdateFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
 }
 
-impl AsyncCharacteristicCallbacks<Vec<u8>> for NfcAccessControlPointCharacteristic {
-    fn on_read_async(&mut self, f: Option<impl OnReadFuture<Vec<u8>>>) {
+impl AsyncCharacteristicCallbacks<crate::tlv::Tlv8> for NfcAccessControlPointCharacteristic {
+    fn on_read_async(&mut self, f: Option<impl OnReadFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_read_async(&mut self.0, f)
     }
 
-    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<Vec<u8>>>) {
+    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_update_async(&mut self.0, f)
     }
 }

--- a/src/characteristic/generated/nfc_access_supported_configuration.rs
+++ b/src/characteristic/generated/nfc_access_supported_configuration.rs
@@ -27,13 +27,13 @@ use crate::{
 // TODO - re-check MaximumDataLength
 /// NFC Access Supported Configuration characteristic.
 #[derive(Debug, Default, Serialize)]
-pub struct NfcAccessSupportedConfigurationCharacteristic(Characteristic<Vec<u8>>);
+pub struct NfcAccessSupportedConfigurationCharacteristic(Characteristic<crate::tlv::Tlv8>);
 
 impl NfcAccessSupportedConfigurationCharacteristic {
     /// Creates a new NFC Access Supported Configuration characteristic.
     pub fn new(id: u64, accessory_id: u64) -> Self {
         #[allow(unused_mut)]
-        let mut c = Self(Characteristic::<Vec<u8>> {
+        let mut c = Self(Characteristic::<crate::tlv::Tlv8> {
             id,
             accessory_id,
             hap_type: HapType::NfcAccessSupportedConfiguration,
@@ -155,18 +155,18 @@ impl HapCharacteristicSetup for NfcAccessSupportedConfigurationCharacteristic {
     }
 }
 
-impl CharacteristicCallbacks<Vec<u8>> for NfcAccessSupportedConfigurationCharacteristic {
-    fn on_read(&mut self, f: Option<impl OnReadFn<Vec<u8>>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
+impl CharacteristicCallbacks<crate::tlv::Tlv8> for NfcAccessSupportedConfigurationCharacteristic {
+    fn on_read(&mut self, f: Option<impl OnReadFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
 
-    fn on_update(&mut self, f: Option<impl OnUpdateFn<Vec<u8>>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
+    fn on_update(&mut self, f: Option<impl OnUpdateFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
 }
 
-impl AsyncCharacteristicCallbacks<Vec<u8>> for NfcAccessSupportedConfigurationCharacteristic {
-    fn on_read_async(&mut self, f: Option<impl OnReadFuture<Vec<u8>>>) {
+impl AsyncCharacteristicCallbacks<crate::tlv::Tlv8> for NfcAccessSupportedConfigurationCharacteristic {
+    fn on_read_async(&mut self, f: Option<impl OnReadFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_read_async(&mut self.0, f)
     }
 
-    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<Vec<u8>>>) {
+    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_update_async(&mut self.0, f)
     }
 }

--- a/src/characteristic/generated/operating_state_response.rs
+++ b/src/characteristic/generated/operating_state_response.rs
@@ -27,13 +27,13 @@ use crate::{
 // TODO - re-check MaximumDataLength
 /// Operating State Response characteristic.
 #[derive(Debug, Default, Serialize)]
-pub struct OperatingStateResponseCharacteristic(Characteristic<Vec<u8>>);
+pub struct OperatingStateResponseCharacteristic(Characteristic<crate::tlv::Tlv8>);
 
 impl OperatingStateResponseCharacteristic {
     /// Creates a new Operating State Response characteristic.
     pub fn new(id: u64, accessory_id: u64) -> Self {
         #[allow(unused_mut)]
-        let mut c = Self(Characteristic::<Vec<u8>> {
+        let mut c = Self(Characteristic::<crate::tlv::Tlv8> {
             id,
             accessory_id,
             hap_type: HapType::OperatingStateResponse,
@@ -156,18 +156,18 @@ impl HapCharacteristicSetup for OperatingStateResponseCharacteristic {
     }
 }
 
-impl CharacteristicCallbacks<Vec<u8>> for OperatingStateResponseCharacteristic {
-    fn on_read(&mut self, f: Option<impl OnReadFn<Vec<u8>>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
+impl CharacteristicCallbacks<crate::tlv::Tlv8> for OperatingStateResponseCharacteristic {
+    fn on_read(&mut self, f: Option<impl OnReadFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
 
-    fn on_update(&mut self, f: Option<impl OnUpdateFn<Vec<u8>>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
+    fn on_update(&mut self, f: Option<impl OnUpdateFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
 }
 
-impl AsyncCharacteristicCallbacks<Vec<u8>> for OperatingStateResponseCharacteristic {
-    fn on_read_async(&mut self, f: Option<impl OnReadFuture<Vec<u8>>>) {
+impl AsyncCharacteristicCallbacks<crate::tlv::Tlv8> for OperatingStateResponseCharacteristic {
+    fn on_read_async(&mut self, f: Option<impl OnReadFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_read_async(&mut self.0, f)
     }
 
-    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<Vec<u8>>>) {
+    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_update_async(&mut self.0, f)
     }
 }

--- a/src/characteristic/generated/pair_setup.rs
+++ b/src/characteristic/generated/pair_setup.rs
@@ -27,13 +27,13 @@ use crate::{
 // TODO - re-check MaximumDataLength
 /// Pair Setup characteristic.
 #[derive(Debug, Default, Serialize)]
-pub struct PairSetupCharacteristic(Characteristic<Vec<u8>>);
+pub struct PairSetupCharacteristic(Characteristic<crate::tlv::Tlv8>);
 
 impl PairSetupCharacteristic {
     /// Creates a new Pair Setup characteristic.
     pub fn new(id: u64, accessory_id: u64) -> Self {
         #[allow(unused_mut)]
-        let mut c = Self(Characteristic::<Vec<u8>> {
+        let mut c = Self(Characteristic::<crate::tlv::Tlv8> {
             id,
             accessory_id,
             hap_type: HapType::PairSetup,
@@ -156,18 +156,18 @@ impl HapCharacteristicSetup for PairSetupCharacteristic {
     }
 }
 
-impl CharacteristicCallbacks<Vec<u8>> for PairSetupCharacteristic {
-    fn on_read(&mut self, f: Option<impl OnReadFn<Vec<u8>>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
+impl CharacteristicCallbacks<crate::tlv::Tlv8> for PairSetupCharacteristic {
+    fn on_read(&mut self, f: Option<impl OnReadFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
 
-    fn on_update(&mut self, f: Option<impl OnUpdateFn<Vec<u8>>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
+    fn on_update(&mut self, f: Option<impl OnUpdateFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
 }
 
-impl AsyncCharacteristicCallbacks<Vec<u8>> for PairSetupCharacteristic {
-    fn on_read_async(&mut self, f: Option<impl OnReadFuture<Vec<u8>>>) {
+impl AsyncCharacteristicCallbacks<crate::tlv::Tlv8> for PairSetupCharacteristic {
+    fn on_read_async(&mut self, f: Option<impl OnReadFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_read_async(&mut self.0, f)
     }
 
-    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<Vec<u8>>>) {
+    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_update_async(&mut self.0, f)
     }
 }

--- a/src/characteristic/generated/pair_verify.rs
+++ b/src/characteristic/generated/pair_verify.rs
@@ -27,13 +27,13 @@ use crate::{
 // TODO - re-check MaximumDataLength
 /// Pair Verify characteristic.
 #[derive(Debug, Default, Serialize)]
-pub struct PairVerifyCharacteristic(Characteristic<Vec<u8>>);
+pub struct PairVerifyCharacteristic(Characteristic<crate::tlv::Tlv8>);
 
 impl PairVerifyCharacteristic {
     /// Creates a new Pair Verify characteristic.
     pub fn new(id: u64, accessory_id: u64) -> Self {
         #[allow(unused_mut)]
-        let mut c = Self(Characteristic::<Vec<u8>> {
+        let mut c = Self(Characteristic::<crate::tlv::Tlv8> {
             id,
             accessory_id,
             hap_type: HapType::PairVerify,
@@ -156,18 +156,18 @@ impl HapCharacteristicSetup for PairVerifyCharacteristic {
     }
 }
 
-impl CharacteristicCallbacks<Vec<u8>> for PairVerifyCharacteristic {
-    fn on_read(&mut self, f: Option<impl OnReadFn<Vec<u8>>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
+impl CharacteristicCallbacks<crate::tlv::Tlv8> for PairVerifyCharacteristic {
+    fn on_read(&mut self, f: Option<impl OnReadFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
 
-    fn on_update(&mut self, f: Option<impl OnUpdateFn<Vec<u8>>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
+    fn on_update(&mut self, f: Option<impl OnUpdateFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
 }
 
-impl AsyncCharacteristicCallbacks<Vec<u8>> for PairVerifyCharacteristic {
-    fn on_read_async(&mut self, f: Option<impl OnReadFuture<Vec<u8>>>) {
+impl AsyncCharacteristicCallbacks<crate::tlv::Tlv8> for PairVerifyCharacteristic {
+    fn on_read_async(&mut self, f: Option<impl OnReadFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_read_async(&mut self.0, f)
     }
 
-    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<Vec<u8>>>) {
+    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_update_async(&mut self.0, f)
     }
 }

--- a/src/characteristic/generated/password_setting.rs
+++ b/src/characteristic/generated/password_setting.rs
@@ -27,13 +27,13 @@ use crate::{
 // TODO - re-check MaximumDataLength
 /// Password Setting characteristic.
 #[derive(Debug, Default, Serialize)]
-pub struct PasswordSettingCharacteristic(Characteristic<Vec<u8>>);
+pub struct PasswordSettingCharacteristic(Characteristic<crate::tlv::Tlv8>);
 
 impl PasswordSettingCharacteristic {
     /// Creates a new Password Setting characteristic.
     pub fn new(id: u64, accessory_id: u64) -> Self {
         #[allow(unused_mut)]
-        let mut c = Self(Characteristic::<Vec<u8>> {
+        let mut c = Self(Characteristic::<crate::tlv::Tlv8> {
             id,
             accessory_id,
             hap_type: HapType::PasswordSetting,
@@ -157,18 +157,18 @@ impl HapCharacteristicSetup for PasswordSettingCharacteristic {
     }
 }
 
-impl CharacteristicCallbacks<Vec<u8>> for PasswordSettingCharacteristic {
-    fn on_read(&mut self, f: Option<impl OnReadFn<Vec<u8>>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
+impl CharacteristicCallbacks<crate::tlv::Tlv8> for PasswordSettingCharacteristic {
+    fn on_read(&mut self, f: Option<impl OnReadFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
 
-    fn on_update(&mut self, f: Option<impl OnUpdateFn<Vec<u8>>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
+    fn on_update(&mut self, f: Option<impl OnUpdateFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
 }
 
-impl AsyncCharacteristicCallbacks<Vec<u8>> for PasswordSettingCharacteristic {
-    fn on_read_async(&mut self, f: Option<impl OnReadFuture<Vec<u8>>>) {
+impl AsyncCharacteristicCallbacks<crate::tlv::Tlv8> for PasswordSettingCharacteristic {
+    fn on_read_async(&mut self, f: Option<impl OnReadFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_read_async(&mut self.0, f)
     }
 
-    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<Vec<u8>>>) {
+    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_update_async(&mut self.0, f)
     }
 }

--- a/src/characteristic/generated/selected_audio_stream_configuration.rs
+++ b/src/characteristic/generated/selected_audio_stream_configuration.rs
@@ -27,13 +27,13 @@ use crate::{
 // TODO - re-check MaximumDataLength
 /// Selected Audio Stream Configuration characteristic.
 #[derive(Debug, Default, Serialize)]
-pub struct SelectedAudioStreamConfigurationCharacteristic(Characteristic<Vec<u8>>);
+pub struct SelectedAudioStreamConfigurationCharacteristic(Characteristic<crate::tlv::Tlv8>);
 
 impl SelectedAudioStreamConfigurationCharacteristic {
     /// Creates a new Selected Audio Stream Configuration characteristic.
     pub fn new(id: u64, accessory_id: u64) -> Self {
         #[allow(unused_mut)]
-        let mut c = Self(Characteristic::<Vec<u8>> {
+        let mut c = Self(Characteristic::<crate::tlv::Tlv8> {
             id,
             accessory_id,
             hap_type: HapType::SelectedAudioStreamConfiguration,
@@ -156,18 +156,18 @@ impl HapCharacteristicSetup for SelectedAudioStreamConfigurationCharacteristic {
     }
 }
 
-impl CharacteristicCallbacks<Vec<u8>> for SelectedAudioStreamConfigurationCharacteristic {
-    fn on_read(&mut self, f: Option<impl OnReadFn<Vec<u8>>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
+impl CharacteristicCallbacks<crate::tlv::Tlv8> for SelectedAudioStreamConfigurationCharacteristic {
+    fn on_read(&mut self, f: Option<impl OnReadFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
 
-    fn on_update(&mut self, f: Option<impl OnUpdateFn<Vec<u8>>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
+    fn on_update(&mut self, f: Option<impl OnUpdateFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
 }
 
-impl AsyncCharacteristicCallbacks<Vec<u8>> for SelectedAudioStreamConfigurationCharacteristic {
-    fn on_read_async(&mut self, f: Option<impl OnReadFuture<Vec<u8>>>) {
+impl AsyncCharacteristicCallbacks<crate::tlv::Tlv8> for SelectedAudioStreamConfigurationCharacteristic {
+    fn on_read_async(&mut self, f: Option<impl OnReadFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_read_async(&mut self.0, f)
     }
 
-    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<Vec<u8>>>) {
+    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_update_async(&mut self.0, f)
     }
 }

--- a/src/characteristic/generated/selected_camera_recording_configuration.rs
+++ b/src/characteristic/generated/selected_camera_recording_configuration.rs
@@ -27,13 +27,13 @@ use crate::{
 // TODO - re-check MaximumDataLength
 /// Selected Camera Recording Configuration characteristic.
 #[derive(Debug, Default, Serialize)]
-pub struct SelectedCameraRecordingConfigurationCharacteristic(Characteristic<Vec<u8>>);
+pub struct SelectedCameraRecordingConfigurationCharacteristic(Characteristic<crate::tlv::Tlv8>);
 
 impl SelectedCameraRecordingConfigurationCharacteristic {
     /// Creates a new Selected Camera Recording Configuration characteristic.
     pub fn new(id: u64, accessory_id: u64) -> Self {
         #[allow(unused_mut)]
-        let mut c = Self(Characteristic::<Vec<u8>> {
+        let mut c = Self(Characteristic::<crate::tlv::Tlv8> {
             id,
             accessory_id,
             hap_type: HapType::SelectedCameraRecordingConfiguration,
@@ -157,18 +157,18 @@ impl HapCharacteristicSetup for SelectedCameraRecordingConfigurationCharacterist
     }
 }
 
-impl CharacteristicCallbacks<Vec<u8>> for SelectedCameraRecordingConfigurationCharacteristic {
-    fn on_read(&mut self, f: Option<impl OnReadFn<Vec<u8>>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
+impl CharacteristicCallbacks<crate::tlv::Tlv8> for SelectedCameraRecordingConfigurationCharacteristic {
+    fn on_read(&mut self, f: Option<impl OnReadFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
 
-    fn on_update(&mut self, f: Option<impl OnUpdateFn<Vec<u8>>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
+    fn on_update(&mut self, f: Option<impl OnUpdateFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
 }
 
-impl AsyncCharacteristicCallbacks<Vec<u8>> for SelectedCameraRecordingConfigurationCharacteristic {
-    fn on_read_async(&mut self, f: Option<impl OnReadFuture<Vec<u8>>>) {
+impl AsyncCharacteristicCallbacks<crate::tlv::Tlv8> for SelectedCameraRecordingConfigurationCharacteristic {
+    fn on_read_async(&mut self, f: Option<impl OnReadFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_read_async(&mut self.0, f)
     }
 
-    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<Vec<u8>>>) {
+    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_update_async(&mut self.0, f)
     }
 }

--- a/src/characteristic/generated/selected_stream_configuration.rs
+++ b/src/characteristic/generated/selected_stream_configuration.rs
@@ -27,13 +27,13 @@ use crate::{
 // TODO - re-check MaximumDataLength
 /// Selected Stream Configuration characteristic.
 #[derive(Debug, Default, Serialize)]
-pub struct SelectedStreamConfigurationCharacteristic(Characteristic<Vec<u8>>);
+pub struct SelectedStreamConfigurationCharacteristic(Characteristic<crate::tlv::Tlv8>);
 
 impl SelectedStreamConfigurationCharacteristic {
     /// Creates a new Selected Stream Configuration characteristic.
     pub fn new(id: u64, accessory_id: u64) -> Self {
         #[allow(unused_mut)]
-        let mut c = Self(Characteristic::<Vec<u8>> {
+        let mut c = Self(Characteristic::<crate::tlv::Tlv8> {
             id,
             accessory_id,
             hap_type: HapType::SelectedStreamConfiguration,
@@ -156,18 +156,18 @@ impl HapCharacteristicSetup for SelectedStreamConfigurationCharacteristic {
     }
 }
 
-impl CharacteristicCallbacks<Vec<u8>> for SelectedStreamConfigurationCharacteristic {
-    fn on_read(&mut self, f: Option<impl OnReadFn<Vec<u8>>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
+impl CharacteristicCallbacks<crate::tlv::Tlv8> for SelectedStreamConfigurationCharacteristic {
+    fn on_read(&mut self, f: Option<impl OnReadFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
 
-    fn on_update(&mut self, f: Option<impl OnUpdateFn<Vec<u8>>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
+    fn on_update(&mut self, f: Option<impl OnUpdateFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
 }
 
-impl AsyncCharacteristicCallbacks<Vec<u8>> for SelectedStreamConfigurationCharacteristic {
-    fn on_read_async(&mut self, f: Option<impl OnReadFuture<Vec<u8>>>) {
+impl AsyncCharacteristicCallbacks<crate::tlv::Tlv8> for SelectedStreamConfigurationCharacteristic {
+    fn on_read_async(&mut self, f: Option<impl OnReadFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_read_async(&mut self.0, f)
     }
 
-    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<Vec<u8>>>) {
+    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_update_async(&mut self.0, f)
     }
 }

--- a/src/characteristic/generated/service_signature.rs
+++ b/src/characteristic/generated/service_signature.rs
@@ -27,13 +27,13 @@ use crate::{
 // TODO - re-check MaximumDataLength
 /// Service Signature characteristic.
 #[derive(Debug, Default, Serialize)]
-pub struct ServiceSignatureCharacteristic(Characteristic<Vec<u8>>);
+pub struct ServiceSignatureCharacteristic(Characteristic<crate::tlv::Tlv8>);
 
 impl ServiceSignatureCharacteristic {
     /// Creates a new Service Signature characteristic.
     pub fn new(id: u64, accessory_id: u64) -> Self {
         #[allow(unused_mut)]
-        let mut c = Self(Characteristic::<Vec<u8>> {
+        let mut c = Self(Characteristic::<crate::tlv::Tlv8> {
             id,
             accessory_id,
             hap_type: HapType::ServiceSignature,
@@ -156,18 +156,18 @@ impl HapCharacteristicSetup for ServiceSignatureCharacteristic {
     }
 }
 
-impl CharacteristicCallbacks<Vec<u8>> for ServiceSignatureCharacteristic {
-    fn on_read(&mut self, f: Option<impl OnReadFn<Vec<u8>>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
+impl CharacteristicCallbacks<crate::tlv::Tlv8> for ServiceSignatureCharacteristic {
+    fn on_read(&mut self, f: Option<impl OnReadFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
 
-    fn on_update(&mut self, f: Option<impl OnUpdateFn<Vec<u8>>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
+    fn on_update(&mut self, f: Option<impl OnUpdateFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
 }
 
-impl AsyncCharacteristicCallbacks<Vec<u8>> for ServiceSignatureCharacteristic {
-    fn on_read_async(&mut self, f: Option<impl OnReadFuture<Vec<u8>>>) {
+impl AsyncCharacteristicCallbacks<crate::tlv::Tlv8> for ServiceSignatureCharacteristic {
+    fn on_read_async(&mut self, f: Option<impl OnReadFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_read_async(&mut self.0, f)
     }
 
-    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<Vec<u8>>>) {
+    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_update_async(&mut self.0, f)
     }
 }

--- a/src/characteristic/generated/setup_data_stream_transport.rs
+++ b/src/characteristic/generated/setup_data_stream_transport.rs
@@ -27,13 +27,13 @@ use crate::{
 // TODO - re-check MaximumDataLength
 /// Setup Data Stream Transport characteristic.
 #[derive(Debug, Default, Serialize)]
-pub struct SetupDataStreamTransportCharacteristic(Characteristic<Vec<u8>>);
+pub struct SetupDataStreamTransportCharacteristic(Characteristic<crate::tlv::Tlv8>);
 
 impl SetupDataStreamTransportCharacteristic {
     /// Creates a new Setup Data Stream Transport characteristic.
     pub fn new(id: u64, accessory_id: u64) -> Self {
         #[allow(unused_mut)]
-        let mut c = Self(Characteristic::<Vec<u8>> {
+        let mut c = Self(Characteristic::<crate::tlv::Tlv8> {
             id,
             accessory_id,
             hap_type: HapType::SetupDataStreamTransport,
@@ -156,18 +156,18 @@ impl HapCharacteristicSetup for SetupDataStreamTransportCharacteristic {
     }
 }
 
-impl CharacteristicCallbacks<Vec<u8>> for SetupDataStreamTransportCharacteristic {
-    fn on_read(&mut self, f: Option<impl OnReadFn<Vec<u8>>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
+impl CharacteristicCallbacks<crate::tlv::Tlv8> for SetupDataStreamTransportCharacteristic {
+    fn on_read(&mut self, f: Option<impl OnReadFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
 
-    fn on_update(&mut self, f: Option<impl OnUpdateFn<Vec<u8>>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
+    fn on_update(&mut self, f: Option<impl OnUpdateFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
 }
 
-impl AsyncCharacteristicCallbacks<Vec<u8>> for SetupDataStreamTransportCharacteristic {
-    fn on_read_async(&mut self, f: Option<impl OnReadFuture<Vec<u8>>>) {
+impl AsyncCharacteristicCallbacks<crate::tlv::Tlv8> for SetupDataStreamTransportCharacteristic {
+    fn on_read_async(&mut self, f: Option<impl OnReadFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_read_async(&mut self.0, f)
     }
 
-    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<Vec<u8>>>) {
+    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_update_async(&mut self.0, f)
     }
 }

--- a/src/characteristic/generated/setup_endpoint.rs
+++ b/src/characteristic/generated/setup_endpoint.rs
@@ -27,13 +27,13 @@ use crate::{
 // TODO - re-check MaximumDataLength
 /// Setup Endpoint characteristic.
 #[derive(Debug, Default, Serialize)]
-pub struct SetupEndpointCharacteristic(Characteristic<Vec<u8>>);
+pub struct SetupEndpointCharacteristic(Characteristic<crate::tlv::Tlv8>);
 
 impl SetupEndpointCharacteristic {
     /// Creates a new Setup Endpoint characteristic.
     pub fn new(id: u64, accessory_id: u64) -> Self {
         #[allow(unused_mut)]
-        let mut c = Self(Characteristic::<Vec<u8>> {
+        let mut c = Self(Characteristic::<crate::tlv::Tlv8> {
             id,
             accessory_id,
             hap_type: HapType::SetupEndpoint,
@@ -156,18 +156,18 @@ impl HapCharacteristicSetup for SetupEndpointCharacteristic {
     }
 }
 
-impl CharacteristicCallbacks<Vec<u8>> for SetupEndpointCharacteristic {
-    fn on_read(&mut self, f: Option<impl OnReadFn<Vec<u8>>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
+impl CharacteristicCallbacks<crate::tlv::Tlv8> for SetupEndpointCharacteristic {
+    fn on_read(&mut self, f: Option<impl OnReadFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
 
-    fn on_update(&mut self, f: Option<impl OnUpdateFn<Vec<u8>>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
+    fn on_update(&mut self, f: Option<impl OnUpdateFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
 }
 
-impl AsyncCharacteristicCallbacks<Vec<u8>> for SetupEndpointCharacteristic {
-    fn on_read_async(&mut self, f: Option<impl OnReadFuture<Vec<u8>>>) {
+impl AsyncCharacteristicCallbacks<crate::tlv::Tlv8> for SetupEndpointCharacteristic {
+    fn on_read_async(&mut self, f: Option<impl OnReadFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_read_async(&mut self.0, f)
     }
 
-    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<Vec<u8>>>) {
+    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_update_async(&mut self.0, f)
     }
 }

--- a/src/characteristic/generated/setup_transfer_transport.rs
+++ b/src/characteristic/generated/setup_transfer_transport.rs
@@ -27,13 +27,13 @@ use crate::{
 // TODO - re-check MaximumDataLength
 /// Setup Transfer Transport characteristic.
 #[derive(Debug, Default, Serialize)]
-pub struct SetupTransferTransportCharacteristic(Characteristic<Vec<u8>>);
+pub struct SetupTransferTransportCharacteristic(Characteristic<crate::tlv::Tlv8>);
 
 impl SetupTransferTransportCharacteristic {
     /// Creates a new Setup Transfer Transport characteristic.
     pub fn new(id: u64, accessory_id: u64) -> Self {
         #[allow(unused_mut)]
-        let mut c = Self(Characteristic::<Vec<u8>> {
+        let mut c = Self(Characteristic::<crate::tlv::Tlv8> {
             id,
             accessory_id,
             hap_type: HapType::SetupTransferTransport,
@@ -156,18 +156,18 @@ impl HapCharacteristicSetup for SetupTransferTransportCharacteristic {
     }
 }
 
-impl CharacteristicCallbacks<Vec<u8>> for SetupTransferTransportCharacteristic {
-    fn on_read(&mut self, f: Option<impl OnReadFn<Vec<u8>>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
+impl CharacteristicCallbacks<crate::tlv::Tlv8> for SetupTransferTransportCharacteristic {
+    fn on_read(&mut self, f: Option<impl OnReadFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
 
-    fn on_update(&mut self, f: Option<impl OnUpdateFn<Vec<u8>>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
+    fn on_update(&mut self, f: Option<impl OnUpdateFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
 }
 
-impl AsyncCharacteristicCallbacks<Vec<u8>> for SetupTransferTransportCharacteristic {
-    fn on_read_async(&mut self, f: Option<impl OnReadFuture<Vec<u8>>>) {
+impl AsyncCharacteristicCallbacks<crate::tlv::Tlv8> for SetupTransferTransportCharacteristic {
+    fn on_read_async(&mut self, f: Option<impl OnReadFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_read_async(&mut self.0, f)
     }
 
-    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<Vec<u8>>>) {
+    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_update_async(&mut self.0, f)
     }
 }

--- a/src/characteristic/generated/siri_endpoint_session_status.rs
+++ b/src/characteristic/generated/siri_endpoint_session_status.rs
@@ -27,13 +27,13 @@ use crate::{
 // TODO - re-check MaximumDataLength
 /// Siri Endpoint Session Status characteristic.
 #[derive(Debug, Default, Serialize)]
-pub struct SiriEndpointSessionStatusCharacteristic(Characteristic<Vec<u8>>);
+pub struct SiriEndpointSessionStatusCharacteristic(Characteristic<crate::tlv::Tlv8>);
 
 impl SiriEndpointSessionStatusCharacteristic {
     /// Creates a new Siri Endpoint Session Status characteristic.
     pub fn new(id: u64, accessory_id: u64) -> Self {
         #[allow(unused_mut)]
-        let mut c = Self(Characteristic::<Vec<u8>> {
+        let mut c = Self(Characteristic::<crate::tlv::Tlv8> {
             id,
             accessory_id,
             hap_type: HapType::SiriEndpointSessionStatus,
@@ -156,18 +156,18 @@ impl HapCharacteristicSetup for SiriEndpointSessionStatusCharacteristic {
     }
 }
 
-impl CharacteristicCallbacks<Vec<u8>> for SiriEndpointSessionStatusCharacteristic {
-    fn on_read(&mut self, f: Option<impl OnReadFn<Vec<u8>>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
+impl CharacteristicCallbacks<crate::tlv::Tlv8> for SiriEndpointSessionStatusCharacteristic {
+    fn on_read(&mut self, f: Option<impl OnReadFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
 
-    fn on_update(&mut self, f: Option<impl OnUpdateFn<Vec<u8>>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
+    fn on_update(&mut self, f: Option<impl OnUpdateFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
 }
 
-impl AsyncCharacteristicCallbacks<Vec<u8>> for SiriEndpointSessionStatusCharacteristic {
-    fn on_read_async(&mut self, f: Option<impl OnReadFuture<Vec<u8>>>) {
+impl AsyncCharacteristicCallbacks<crate::tlv::Tlv8> for SiriEndpointSessionStatusCharacteristic {
+    fn on_read_async(&mut self, f: Option<impl OnReadFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_read_async(&mut self.0, f)
     }
 
-    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<Vec<u8>>>) {
+    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_update_async(&mut self.0, f)
     }
 }

--- a/src/characteristic/generated/streaming_status.rs
+++ b/src/characteristic/generated/streaming_status.rs
@@ -27,13 +27,13 @@ use crate::{
 // TODO - re-check MaximumDataLength
 /// Streaming Status characteristic.
 #[derive(Debug, Default, Serialize)]
-pub struct StreamingStatusCharacteristic(Characteristic<Vec<u8>>);
+pub struct StreamingStatusCharacteristic(Characteristic<crate::tlv::Tlv8>);
 
 impl StreamingStatusCharacteristic {
     /// Creates a new Streaming Status characteristic.
     pub fn new(id: u64, accessory_id: u64) -> Self {
         #[allow(unused_mut)]
-        let mut c = Self(Characteristic::<Vec<u8>> {
+        let mut c = Self(Characteristic::<crate::tlv::Tlv8> {
             id,
             accessory_id,
             hap_type: HapType::StreamingStatus,
@@ -156,18 +156,18 @@ impl HapCharacteristicSetup for StreamingStatusCharacteristic {
     }
 }
 
-impl CharacteristicCallbacks<Vec<u8>> for StreamingStatusCharacteristic {
-    fn on_read(&mut self, f: Option<impl OnReadFn<Vec<u8>>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
+impl CharacteristicCallbacks<crate::tlv::Tlv8> for StreamingStatusCharacteristic {
+    fn on_read(&mut self, f: Option<impl OnReadFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
 
-    fn on_update(&mut self, f: Option<impl OnUpdateFn<Vec<u8>>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
+    fn on_update(&mut self, f: Option<impl OnUpdateFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
 }
 
-impl AsyncCharacteristicCallbacks<Vec<u8>> for StreamingStatusCharacteristic {
-    fn on_read_async(&mut self, f: Option<impl OnReadFuture<Vec<u8>>>) {
+impl AsyncCharacteristicCallbacks<crate::tlv::Tlv8> for StreamingStatusCharacteristic {
+    fn on_read_async(&mut self, f: Option<impl OnReadFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_read_async(&mut self.0, f)
     }
 
-    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<Vec<u8>>>) {
+    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_update_async(&mut self.0, f)
     }
 }

--- a/src/characteristic/generated/supported_audio_recording_configuration.rs
+++ b/src/characteristic/generated/supported_audio_recording_configuration.rs
@@ -27,13 +27,13 @@ use crate::{
 // TODO - re-check MaximumDataLength
 /// Supported Audio Recording Configuration characteristic.
 #[derive(Debug, Default, Serialize)]
-pub struct SupportedAudioRecordingConfigurationCharacteristic(Characteristic<Vec<u8>>);
+pub struct SupportedAudioRecordingConfigurationCharacteristic(Characteristic<crate::tlv::Tlv8>);
 
 impl SupportedAudioRecordingConfigurationCharacteristic {
     /// Creates a new Supported Audio Recording Configuration characteristic.
     pub fn new(id: u64, accessory_id: u64) -> Self {
         #[allow(unused_mut)]
-        let mut c = Self(Characteristic::<Vec<u8>> {
+        let mut c = Self(Characteristic::<crate::tlv::Tlv8> {
             id,
             accessory_id,
             hap_type: HapType::SupportedAudioRecordingConfiguration,
@@ -156,18 +156,18 @@ impl HapCharacteristicSetup for SupportedAudioRecordingConfigurationCharacterist
     }
 }
 
-impl CharacteristicCallbacks<Vec<u8>> for SupportedAudioRecordingConfigurationCharacteristic {
-    fn on_read(&mut self, f: Option<impl OnReadFn<Vec<u8>>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
+impl CharacteristicCallbacks<crate::tlv::Tlv8> for SupportedAudioRecordingConfigurationCharacteristic {
+    fn on_read(&mut self, f: Option<impl OnReadFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
 
-    fn on_update(&mut self, f: Option<impl OnUpdateFn<Vec<u8>>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
+    fn on_update(&mut self, f: Option<impl OnUpdateFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
 }
 
-impl AsyncCharacteristicCallbacks<Vec<u8>> for SupportedAudioRecordingConfigurationCharacteristic {
-    fn on_read_async(&mut self, f: Option<impl OnReadFuture<Vec<u8>>>) {
+impl AsyncCharacteristicCallbacks<crate::tlv::Tlv8> for SupportedAudioRecordingConfigurationCharacteristic {
+    fn on_read_async(&mut self, f: Option<impl OnReadFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_read_async(&mut self.0, f)
     }
 
-    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<Vec<u8>>>) {
+    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_update_async(&mut self.0, f)
     }
 }

--- a/src/characteristic/generated/supported_audio_stream_configuration.rs
+++ b/src/characteristic/generated/supported_audio_stream_configuration.rs
@@ -27,13 +27,13 @@ use crate::{
 // TODO - re-check MaximumDataLength
 /// Supported Audio Stream Configuration characteristic.
 #[derive(Debug, Default, Serialize)]
-pub struct SupportedAudioStreamConfigurationCharacteristic(Characteristic<Vec<u8>>);
+pub struct SupportedAudioStreamConfigurationCharacteristic(Characteristic<crate::tlv::Tlv8>);
 
 impl SupportedAudioStreamConfigurationCharacteristic {
     /// Creates a new Supported Audio Stream Configuration characteristic.
     pub fn new(id: u64, accessory_id: u64) -> Self {
         #[allow(unused_mut)]
-        let mut c = Self(Characteristic::<Vec<u8>> {
+        let mut c = Self(Characteristic::<crate::tlv::Tlv8> {
             id,
             accessory_id,
             hap_type: HapType::SupportedAudioStreamConfiguration,
@@ -155,18 +155,18 @@ impl HapCharacteristicSetup for SupportedAudioStreamConfigurationCharacteristic 
     }
 }
 
-impl CharacteristicCallbacks<Vec<u8>> for SupportedAudioStreamConfigurationCharacteristic {
-    fn on_read(&mut self, f: Option<impl OnReadFn<Vec<u8>>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
+impl CharacteristicCallbacks<crate::tlv::Tlv8> for SupportedAudioStreamConfigurationCharacteristic {
+    fn on_read(&mut self, f: Option<impl OnReadFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
 
-    fn on_update(&mut self, f: Option<impl OnUpdateFn<Vec<u8>>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
+    fn on_update(&mut self, f: Option<impl OnUpdateFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
 }
 
-impl AsyncCharacteristicCallbacks<Vec<u8>> for SupportedAudioStreamConfigurationCharacteristic {
-    fn on_read_async(&mut self, f: Option<impl OnReadFuture<Vec<u8>>>) {
+impl AsyncCharacteristicCallbacks<crate::tlv::Tlv8> for SupportedAudioStreamConfigurationCharacteristic {
+    fn on_read_async(&mut self, f: Option<impl OnReadFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_read_async(&mut self.0, f)
     }
 
-    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<Vec<u8>>>) {
+    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_update_async(&mut self.0, f)
     }
 }

--- a/src/characteristic/generated/supported_camera_recording_configuration.rs
+++ b/src/characteristic/generated/supported_camera_recording_configuration.rs
@@ -27,13 +27,13 @@ use crate::{
 // TODO - re-check MaximumDataLength
 /// Supported Camera Recording Configuration characteristic.
 #[derive(Debug, Default, Serialize)]
-pub struct SupportedCameraRecordingConfigurationCharacteristic(Characteristic<Vec<u8>>);
+pub struct SupportedCameraRecordingConfigurationCharacteristic(Characteristic<crate::tlv::Tlv8>);
 
 impl SupportedCameraRecordingConfigurationCharacteristic {
     /// Creates a new Supported Camera Recording Configuration characteristic.
     pub fn new(id: u64, accessory_id: u64) -> Self {
         #[allow(unused_mut)]
-        let mut c = Self(Characteristic::<Vec<u8>> {
+        let mut c = Self(Characteristic::<crate::tlv::Tlv8> {
             id,
             accessory_id,
             hap_type: HapType::SupportedCameraRecordingConfiguration,
@@ -156,18 +156,18 @@ impl HapCharacteristicSetup for SupportedCameraRecordingConfigurationCharacteris
     }
 }
 
-impl CharacteristicCallbacks<Vec<u8>> for SupportedCameraRecordingConfigurationCharacteristic {
-    fn on_read(&mut self, f: Option<impl OnReadFn<Vec<u8>>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
+impl CharacteristicCallbacks<crate::tlv::Tlv8> for SupportedCameraRecordingConfigurationCharacteristic {
+    fn on_read(&mut self, f: Option<impl OnReadFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
 
-    fn on_update(&mut self, f: Option<impl OnUpdateFn<Vec<u8>>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
+    fn on_update(&mut self, f: Option<impl OnUpdateFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
 }
 
-impl AsyncCharacteristicCallbacks<Vec<u8>> for SupportedCameraRecordingConfigurationCharacteristic {
-    fn on_read_async(&mut self, f: Option<impl OnReadFuture<Vec<u8>>>) {
+impl AsyncCharacteristicCallbacks<crate::tlv::Tlv8> for SupportedCameraRecordingConfigurationCharacteristic {
+    fn on_read_async(&mut self, f: Option<impl OnReadFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_read_async(&mut self.0, f)
     }
 
-    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<Vec<u8>>>) {
+    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_update_async(&mut self.0, f)
     }
 }

--- a/src/characteristic/generated/supported_characteristic_value_transition_configuration.rs
+++ b/src/characteristic/generated/supported_characteristic_value_transition_configuration.rs
@@ -27,13 +27,13 @@ use crate::{
 // TODO - re-check MaximumDataLength
 /// Supported Characteristic Value Transition Configuration characteristic.
 #[derive(Debug, Default, Serialize)]
-pub struct SupportedCharacteristicValueTransitionConfigurationCharacteristic(Characteristic<Vec<u8>>);
+pub struct SupportedCharacteristicValueTransitionConfigurationCharacteristic(Characteristic<crate::tlv::Tlv8>);
 
 impl SupportedCharacteristicValueTransitionConfigurationCharacteristic {
     /// Creates a new Supported Characteristic Value Transition Configuration characteristic.
     pub fn new(id: u64, accessory_id: u64) -> Self {
         #[allow(unused_mut)]
-        let mut c = Self(Characteristic::<Vec<u8>> {
+        let mut c = Self(Characteristic::<crate::tlv::Tlv8> {
             id,
             accessory_id,
             hap_type: HapType::SupportedCharacteristicValueTransitionConfiguration,
@@ -155,18 +155,18 @@ impl HapCharacteristicSetup for SupportedCharacteristicValueTransitionConfigurat
     }
 }
 
-impl CharacteristicCallbacks<Vec<u8>> for SupportedCharacteristicValueTransitionConfigurationCharacteristic {
-    fn on_read(&mut self, f: Option<impl OnReadFn<Vec<u8>>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
+impl CharacteristicCallbacks<crate::tlv::Tlv8> for SupportedCharacteristicValueTransitionConfigurationCharacteristic {
+    fn on_read(&mut self, f: Option<impl OnReadFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
 
-    fn on_update(&mut self, f: Option<impl OnUpdateFn<Vec<u8>>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
+    fn on_update(&mut self, f: Option<impl OnUpdateFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
 }
 
-impl AsyncCharacteristicCallbacks<Vec<u8>> for SupportedCharacteristicValueTransitionConfigurationCharacteristic {
-    fn on_read_async(&mut self, f: Option<impl OnReadFuture<Vec<u8>>>) {
+impl AsyncCharacteristicCallbacks<crate::tlv::Tlv8> for SupportedCharacteristicValueTransitionConfigurationCharacteristic {
+    fn on_read_async(&mut self, f: Option<impl OnReadFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_read_async(&mut self.0, f)
     }
 
-    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<Vec<u8>>>) {
+    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_update_async(&mut self.0, f)
     }
 }

--- a/src/characteristic/generated/supported_data_stream_transport_configuration.rs
+++ b/src/characteristic/generated/supported_data_stream_transport_configuration.rs
@@ -27,13 +27,13 @@ use crate::{
 // TODO - re-check MaximumDataLength
 /// Supported Data Stream Transport Configuration characteristic.
 #[derive(Debug, Default, Serialize)]
-pub struct SupportedDataStreamTransportConfigurationCharacteristic(Characteristic<Vec<u8>>);
+pub struct SupportedDataStreamTransportConfigurationCharacteristic(Characteristic<crate::tlv::Tlv8>);
 
 impl SupportedDataStreamTransportConfigurationCharacteristic {
     /// Creates a new Supported Data Stream Transport Configuration characteristic.
     pub fn new(id: u64, accessory_id: u64) -> Self {
         #[allow(unused_mut)]
-        let mut c = Self(Characteristic::<Vec<u8>> {
+        let mut c = Self(Characteristic::<crate::tlv::Tlv8> {
             id,
             accessory_id,
             hap_type: HapType::SupportedDataStreamTransportConfiguration,
@@ -155,18 +155,18 @@ impl HapCharacteristicSetup for SupportedDataStreamTransportConfigurationCharact
     }
 }
 
-impl CharacteristicCallbacks<Vec<u8>> for SupportedDataStreamTransportConfigurationCharacteristic {
-    fn on_read(&mut self, f: Option<impl OnReadFn<Vec<u8>>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
+impl CharacteristicCallbacks<crate::tlv::Tlv8> for SupportedDataStreamTransportConfigurationCharacteristic {
+    fn on_read(&mut self, f: Option<impl OnReadFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
 
-    fn on_update(&mut self, f: Option<impl OnUpdateFn<Vec<u8>>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
+    fn on_update(&mut self, f: Option<impl OnUpdateFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
 }
 
-impl AsyncCharacteristicCallbacks<Vec<u8>> for SupportedDataStreamTransportConfigurationCharacteristic {
-    fn on_read_async(&mut self, f: Option<impl OnReadFuture<Vec<u8>>>) {
+impl AsyncCharacteristicCallbacks<crate::tlv::Tlv8> for SupportedDataStreamTransportConfigurationCharacteristic {
+    fn on_read_async(&mut self, f: Option<impl OnReadFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_read_async(&mut self.0, f)
     }
 
-    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<Vec<u8>>>) {
+    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_update_async(&mut self.0, f)
     }
 }

--- a/src/characteristic/generated/supported_diagnostics_snapshot.rs
+++ b/src/characteristic/generated/supported_diagnostics_snapshot.rs
@@ -27,13 +27,13 @@ use crate::{
 // TODO - re-check MaximumDataLength
 /// Supported Diagnostics Snapshot characteristic.
 #[derive(Debug, Default, Serialize)]
-pub struct SupportedDiagnosticsSnapshotCharacteristic(Characteristic<Vec<u8>>);
+pub struct SupportedDiagnosticsSnapshotCharacteristic(Characteristic<crate::tlv::Tlv8>);
 
 impl SupportedDiagnosticsSnapshotCharacteristic {
     /// Creates a new Supported Diagnostics Snapshot characteristic.
     pub fn new(id: u64, accessory_id: u64) -> Self {
         #[allow(unused_mut)]
-        let mut c = Self(Characteristic::<Vec<u8>> {
+        let mut c = Self(Characteristic::<crate::tlv::Tlv8> {
             id,
             accessory_id,
             hap_type: HapType::SupportedDiagnosticsSnapshot,
@@ -155,18 +155,18 @@ impl HapCharacteristicSetup for SupportedDiagnosticsSnapshotCharacteristic {
     }
 }
 
-impl CharacteristicCallbacks<Vec<u8>> for SupportedDiagnosticsSnapshotCharacteristic {
-    fn on_read(&mut self, f: Option<impl OnReadFn<Vec<u8>>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
+impl CharacteristicCallbacks<crate::tlv::Tlv8> for SupportedDiagnosticsSnapshotCharacteristic {
+    fn on_read(&mut self, f: Option<impl OnReadFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
 
-    fn on_update(&mut self, f: Option<impl OnUpdateFn<Vec<u8>>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
+    fn on_update(&mut self, f: Option<impl OnUpdateFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
 }
 
-impl AsyncCharacteristicCallbacks<Vec<u8>> for SupportedDiagnosticsSnapshotCharacteristic {
-    fn on_read_async(&mut self, f: Option<impl OnReadFuture<Vec<u8>>>) {
+impl AsyncCharacteristicCallbacks<crate::tlv::Tlv8> for SupportedDiagnosticsSnapshotCharacteristic {
+    fn on_read_async(&mut self, f: Option<impl OnReadFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_read_async(&mut self.0, f)
     }
 
-    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<Vec<u8>>>) {
+    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_update_async(&mut self.0, f)
     }
 }

--- a/src/characteristic/generated/supported_firmware_update_configuration.rs
+++ b/src/characteristic/generated/supported_firmware_update_configuration.rs
@@ -27,13 +27,13 @@ use crate::{
 // TODO - re-check MaximumDataLength
 /// Supported Firmware Update Configuration characteristic.
 #[derive(Debug, Default, Serialize)]
-pub struct SupportedFirmwareUpdateConfigurationCharacteristic(Characteristic<Vec<u8>>);
+pub struct SupportedFirmwareUpdateConfigurationCharacteristic(Characteristic<crate::tlv::Tlv8>);
 
 impl SupportedFirmwareUpdateConfigurationCharacteristic {
     /// Creates a new Supported Firmware Update Configuration characteristic.
     pub fn new(id: u64, accessory_id: u64) -> Self {
         #[allow(unused_mut)]
-        let mut c = Self(Characteristic::<Vec<u8>> {
+        let mut c = Self(Characteristic::<crate::tlv::Tlv8> {
             id,
             accessory_id,
             hap_type: HapType::SupportedFirmwareUpdateConfiguration,
@@ -155,18 +155,18 @@ impl HapCharacteristicSetup for SupportedFirmwareUpdateConfigurationCharacterist
     }
 }
 
-impl CharacteristicCallbacks<Vec<u8>> for SupportedFirmwareUpdateConfigurationCharacteristic {
-    fn on_read(&mut self, f: Option<impl OnReadFn<Vec<u8>>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
+impl CharacteristicCallbacks<crate::tlv::Tlv8> for SupportedFirmwareUpdateConfigurationCharacteristic {
+    fn on_read(&mut self, f: Option<impl OnReadFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
 
-    fn on_update(&mut self, f: Option<impl OnUpdateFn<Vec<u8>>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
+    fn on_update(&mut self, f: Option<impl OnUpdateFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
 }
 
-impl AsyncCharacteristicCallbacks<Vec<u8>> for SupportedFirmwareUpdateConfigurationCharacteristic {
-    fn on_read_async(&mut self, f: Option<impl OnReadFuture<Vec<u8>>>) {
+impl AsyncCharacteristicCallbacks<crate::tlv::Tlv8> for SupportedFirmwareUpdateConfigurationCharacteristic {
+    fn on_read_async(&mut self, f: Option<impl OnReadFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_read_async(&mut self.0, f)
     }
 
-    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<Vec<u8>>>) {
+    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_update_async(&mut self.0, f)
     }
 }

--- a/src/characteristic/generated/supported_router_configuration.rs
+++ b/src/characteristic/generated/supported_router_configuration.rs
@@ -27,13 +27,13 @@ use crate::{
 // TODO - re-check MaximumDataLength
 /// Supported Router Configuration characteristic.
 #[derive(Debug, Default, Serialize)]
-pub struct SupportedRouterConfigurationCharacteristic(Characteristic<Vec<u8>>);
+pub struct SupportedRouterConfigurationCharacteristic(Characteristic<crate::tlv::Tlv8>);
 
 impl SupportedRouterConfigurationCharacteristic {
     /// Creates a new Supported Router Configuration characteristic.
     pub fn new(id: u64, accessory_id: u64) -> Self {
         #[allow(unused_mut)]
-        let mut c = Self(Characteristic::<Vec<u8>> {
+        let mut c = Self(Characteristic::<crate::tlv::Tlv8> {
             id,
             accessory_id,
             hap_type: HapType::SupportedRouterConfiguration,
@@ -155,18 +155,18 @@ impl HapCharacteristicSetup for SupportedRouterConfigurationCharacteristic {
     }
 }
 
-impl CharacteristicCallbacks<Vec<u8>> for SupportedRouterConfigurationCharacteristic {
-    fn on_read(&mut self, f: Option<impl OnReadFn<Vec<u8>>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
+impl CharacteristicCallbacks<crate::tlv::Tlv8> for SupportedRouterConfigurationCharacteristic {
+    fn on_read(&mut self, f: Option<impl OnReadFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
 
-    fn on_update(&mut self, f: Option<impl OnUpdateFn<Vec<u8>>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
+    fn on_update(&mut self, f: Option<impl OnUpdateFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
 }
 
-impl AsyncCharacteristicCallbacks<Vec<u8>> for SupportedRouterConfigurationCharacteristic {
-    fn on_read_async(&mut self, f: Option<impl OnReadFuture<Vec<u8>>>) {
+impl AsyncCharacteristicCallbacks<crate::tlv::Tlv8> for SupportedRouterConfigurationCharacteristic {
+    fn on_read_async(&mut self, f: Option<impl OnReadFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_read_async(&mut self.0, f)
     }
 
-    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<Vec<u8>>>) {
+    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_update_async(&mut self.0, f)
     }
 }

--- a/src/characteristic/generated/supported_rtp_configuration.rs
+++ b/src/characteristic/generated/supported_rtp_configuration.rs
@@ -27,13 +27,13 @@ use crate::{
 // TODO - re-check MaximumDataLength
 /// Supported RTP Configuration characteristic.
 #[derive(Debug, Default, Serialize)]
-pub struct SupportedRtpConfigurationCharacteristic(Characteristic<Vec<u8>>);
+pub struct SupportedRtpConfigurationCharacteristic(Characteristic<crate::tlv::Tlv8>);
 
 impl SupportedRtpConfigurationCharacteristic {
     /// Creates a new Supported RTP Configuration characteristic.
     pub fn new(id: u64, accessory_id: u64) -> Self {
         #[allow(unused_mut)]
-        let mut c = Self(Characteristic::<Vec<u8>> {
+        let mut c = Self(Characteristic::<crate::tlv::Tlv8> {
             id,
             accessory_id,
             hap_type: HapType::SupportedRtpConfiguration,
@@ -155,18 +155,18 @@ impl HapCharacteristicSetup for SupportedRtpConfigurationCharacteristic {
     }
 }
 
-impl CharacteristicCallbacks<Vec<u8>> for SupportedRtpConfigurationCharacteristic {
-    fn on_read(&mut self, f: Option<impl OnReadFn<Vec<u8>>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
+impl CharacteristicCallbacks<crate::tlv::Tlv8> for SupportedRtpConfigurationCharacteristic {
+    fn on_read(&mut self, f: Option<impl OnReadFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
 
-    fn on_update(&mut self, f: Option<impl OnUpdateFn<Vec<u8>>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
+    fn on_update(&mut self, f: Option<impl OnUpdateFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
 }
 
-impl AsyncCharacteristicCallbacks<Vec<u8>> for SupportedRtpConfigurationCharacteristic {
-    fn on_read_async(&mut self, f: Option<impl OnReadFuture<Vec<u8>>>) {
+impl AsyncCharacteristicCallbacks<crate::tlv::Tlv8> for SupportedRtpConfigurationCharacteristic {
+    fn on_read_async(&mut self, f: Option<impl OnReadFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_read_async(&mut self.0, f)
     }
 
-    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<Vec<u8>>>) {
+    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_update_async(&mut self.0, f)
     }
 }

--- a/src/characteristic/generated/supported_target_configuration.rs
+++ b/src/characteristic/generated/supported_target_configuration.rs
@@ -27,13 +27,13 @@ use crate::{
 // TODO - re-check MaximumDataLength
 /// Supported Target Configuration characteristic.
 #[derive(Debug, Default, Serialize)]
-pub struct SupportedTargetConfigurationCharacteristic(Characteristic<Vec<u8>>);
+pub struct SupportedTargetConfigurationCharacteristic(Characteristic<crate::tlv::Tlv8>);
 
 impl SupportedTargetConfigurationCharacteristic {
     /// Creates a new Supported Target Configuration characteristic.
     pub fn new(id: u64, accessory_id: u64) -> Self {
         #[allow(unused_mut)]
-        let mut c = Self(Characteristic::<Vec<u8>> {
+        let mut c = Self(Characteristic::<crate::tlv::Tlv8> {
             id,
             accessory_id,
             hap_type: HapType::SupportedTargetConfiguration,
@@ -155,18 +155,18 @@ impl HapCharacteristicSetup for SupportedTargetConfigurationCharacteristic {
     }
 }
 
-impl CharacteristicCallbacks<Vec<u8>> for SupportedTargetConfigurationCharacteristic {
-    fn on_read(&mut self, f: Option<impl OnReadFn<Vec<u8>>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
+impl CharacteristicCallbacks<crate::tlv::Tlv8> for SupportedTargetConfigurationCharacteristic {
+    fn on_read(&mut self, f: Option<impl OnReadFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
 
-    fn on_update(&mut self, f: Option<impl OnUpdateFn<Vec<u8>>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
+    fn on_update(&mut self, f: Option<impl OnUpdateFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
 }
 
-impl AsyncCharacteristicCallbacks<Vec<u8>> for SupportedTargetConfigurationCharacteristic {
-    fn on_read_async(&mut self, f: Option<impl OnReadFuture<Vec<u8>>>) {
+impl AsyncCharacteristicCallbacks<crate::tlv::Tlv8> for SupportedTargetConfigurationCharacteristic {
+    fn on_read_async(&mut self, f: Option<impl OnReadFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_read_async(&mut self.0, f)
     }
 
-    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<Vec<u8>>>) {
+    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_update_async(&mut self.0, f)
     }
 }

--- a/src/characteristic/generated/supported_transfer_transport_configuration.rs
+++ b/src/characteristic/generated/supported_transfer_transport_configuration.rs
@@ -27,13 +27,13 @@ use crate::{
 // TODO - re-check MaximumDataLength
 /// Supported Transfer Transport Configuration characteristic.
 #[derive(Debug, Default, Serialize)]
-pub struct SupportedTransferTransportConfigurationCharacteristic(Characteristic<Vec<u8>>);
+pub struct SupportedTransferTransportConfigurationCharacteristic(Characteristic<crate::tlv::Tlv8>);
 
 impl SupportedTransferTransportConfigurationCharacteristic {
     /// Creates a new Supported Transfer Transport Configuration characteristic.
     pub fn new(id: u64, accessory_id: u64) -> Self {
         #[allow(unused_mut)]
-        let mut c = Self(Characteristic::<Vec<u8>> {
+        let mut c = Self(Characteristic::<crate::tlv::Tlv8> {
             id,
             accessory_id,
             hap_type: HapType::SupportedTransferTransportConfiguration,
@@ -155,18 +155,18 @@ impl HapCharacteristicSetup for SupportedTransferTransportConfigurationCharacter
     }
 }
 
-impl CharacteristicCallbacks<Vec<u8>> for SupportedTransferTransportConfigurationCharacteristic {
-    fn on_read(&mut self, f: Option<impl OnReadFn<Vec<u8>>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
+impl CharacteristicCallbacks<crate::tlv::Tlv8> for SupportedTransferTransportConfigurationCharacteristic {
+    fn on_read(&mut self, f: Option<impl OnReadFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
 
-    fn on_update(&mut self, f: Option<impl OnUpdateFn<Vec<u8>>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
+    fn on_update(&mut self, f: Option<impl OnUpdateFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
 }
 
-impl AsyncCharacteristicCallbacks<Vec<u8>> for SupportedTransferTransportConfigurationCharacteristic {
-    fn on_read_async(&mut self, f: Option<impl OnReadFuture<Vec<u8>>>) {
+impl AsyncCharacteristicCallbacks<crate::tlv::Tlv8> for SupportedTransferTransportConfigurationCharacteristic {
+    fn on_read_async(&mut self, f: Option<impl OnReadFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_read_async(&mut self.0, f)
     }
 
-    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<Vec<u8>>>) {
+    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_update_async(&mut self.0, f)
     }
 }

--- a/src/characteristic/generated/supported_video_recording_configuration.rs
+++ b/src/characteristic/generated/supported_video_recording_configuration.rs
@@ -27,13 +27,13 @@ use crate::{
 // TODO - re-check MaximumDataLength
 /// Supported Video Recording Configuration characteristic.
 #[derive(Debug, Default, Serialize)]
-pub struct SupportedVideoRecordingConfigurationCharacteristic(Characteristic<Vec<u8>>);
+pub struct SupportedVideoRecordingConfigurationCharacteristic(Characteristic<crate::tlv::Tlv8>);
 
 impl SupportedVideoRecordingConfigurationCharacteristic {
     /// Creates a new Supported Video Recording Configuration characteristic.
     pub fn new(id: u64, accessory_id: u64) -> Self {
         #[allow(unused_mut)]
-        let mut c = Self(Characteristic::<Vec<u8>> {
+        let mut c = Self(Characteristic::<crate::tlv::Tlv8> {
             id,
             accessory_id,
             hap_type: HapType::SupportedVideoRecordingConfiguration,
@@ -156,18 +156,18 @@ impl HapCharacteristicSetup for SupportedVideoRecordingConfigurationCharacterist
     }
 }
 
-impl CharacteristicCallbacks<Vec<u8>> for SupportedVideoRecordingConfigurationCharacteristic {
-    fn on_read(&mut self, f: Option<impl OnReadFn<Vec<u8>>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
+impl CharacteristicCallbacks<crate::tlv::Tlv8> for SupportedVideoRecordingConfigurationCharacteristic {
+    fn on_read(&mut self, f: Option<impl OnReadFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
 
-    fn on_update(&mut self, f: Option<impl OnUpdateFn<Vec<u8>>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
+    fn on_update(&mut self, f: Option<impl OnUpdateFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
 }
 
-impl AsyncCharacteristicCallbacks<Vec<u8>> for SupportedVideoRecordingConfigurationCharacteristic {
-    fn on_read_async(&mut self, f: Option<impl OnReadFuture<Vec<u8>>>) {
+impl AsyncCharacteristicCallbacks<crate::tlv::Tlv8> for SupportedVideoRecordingConfigurationCharacteristic {
+    fn on_read_async(&mut self, f: Option<impl OnReadFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_read_async(&mut self.0, f)
     }
 
-    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<Vec<u8>>>) {
+    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_update_async(&mut self.0, f)
     }
 }

--- a/src/characteristic/generated/supported_video_stream_configuration.rs
+++ b/src/characteristic/generated/supported_video_stream_configuration.rs
@@ -27,13 +27,13 @@ use crate::{
 // TODO - re-check MaximumDataLength
 /// Supported Video Stream Configuration characteristic.
 #[derive(Debug, Default, Serialize)]
-pub struct SupportedVideoStreamConfigurationCharacteristic(Characteristic<Vec<u8>>);
+pub struct SupportedVideoStreamConfigurationCharacteristic(Characteristic<crate::tlv::Tlv8>);
 
 impl SupportedVideoStreamConfigurationCharacteristic {
     /// Creates a new Supported Video Stream Configuration characteristic.
     pub fn new(id: u64, accessory_id: u64) -> Self {
         #[allow(unused_mut)]
-        let mut c = Self(Characteristic::<Vec<u8>> {
+        let mut c = Self(Characteristic::<crate::tlv::Tlv8> {
             id,
             accessory_id,
             hap_type: HapType::SupportedVideoStreamConfiguration,
@@ -155,18 +155,18 @@ impl HapCharacteristicSetup for SupportedVideoStreamConfigurationCharacteristic 
     }
 }
 
-impl CharacteristicCallbacks<Vec<u8>> for SupportedVideoStreamConfigurationCharacteristic {
-    fn on_read(&mut self, f: Option<impl OnReadFn<Vec<u8>>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
+impl CharacteristicCallbacks<crate::tlv::Tlv8> for SupportedVideoStreamConfigurationCharacteristic {
+    fn on_read(&mut self, f: Option<impl OnReadFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
 
-    fn on_update(&mut self, f: Option<impl OnUpdateFn<Vec<u8>>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
+    fn on_update(&mut self, f: Option<impl OnUpdateFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
 }
 
-impl AsyncCharacteristicCallbacks<Vec<u8>> for SupportedVideoStreamConfigurationCharacteristic {
-    fn on_read_async(&mut self, f: Option<impl OnReadFuture<Vec<u8>>>) {
+impl AsyncCharacteristicCallbacks<crate::tlv::Tlv8> for SupportedVideoStreamConfigurationCharacteristic {
+    fn on_read_async(&mut self, f: Option<impl OnReadFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_read_async(&mut self.0, f)
     }
 
-    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<Vec<u8>>>) {
+    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_update_async(&mut self.0, f)
     }
 }

--- a/src/characteristic/generated/target_list_configuration.rs
+++ b/src/characteristic/generated/target_list_configuration.rs
@@ -27,13 +27,13 @@ use crate::{
 // TODO - re-check MaximumDataLength
 /// Target List Configuration characteristic.
 #[derive(Debug, Default, Serialize)]
-pub struct TargetListConfigurationCharacteristic(Characteristic<Vec<u8>>);
+pub struct TargetListConfigurationCharacteristic(Characteristic<crate::tlv::Tlv8>);
 
 impl TargetListConfigurationCharacteristic {
     /// Creates a new Target List Configuration characteristic.
     pub fn new(id: u64, accessory_id: u64) -> Self {
         #[allow(unused_mut)]
-        let mut c = Self(Characteristic::<Vec<u8>> {
+        let mut c = Self(Characteristic::<crate::tlv::Tlv8> {
             id,
             accessory_id,
             hap_type: HapType::TargetListConfiguration,
@@ -157,18 +157,18 @@ impl HapCharacteristicSetup for TargetListConfigurationCharacteristic {
     }
 }
 
-impl CharacteristicCallbacks<Vec<u8>> for TargetListConfigurationCharacteristic {
-    fn on_read(&mut self, f: Option<impl OnReadFn<Vec<u8>>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
+impl CharacteristicCallbacks<crate::tlv::Tlv8> for TargetListConfigurationCharacteristic {
+    fn on_read(&mut self, f: Option<impl OnReadFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
 
-    fn on_update(&mut self, f: Option<impl OnUpdateFn<Vec<u8>>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
+    fn on_update(&mut self, f: Option<impl OnUpdateFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
 }
 
-impl AsyncCharacteristicCallbacks<Vec<u8>> for TargetListConfigurationCharacteristic {
-    fn on_read_async(&mut self, f: Option<impl OnReadFuture<Vec<u8>>>) {
+impl AsyncCharacteristicCallbacks<crate::tlv::Tlv8> for TargetListConfigurationCharacteristic {
+    fn on_read_async(&mut self, f: Option<impl OnReadFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_read_async(&mut self.0, f)
     }
 
-    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<Vec<u8>>>) {
+    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_update_async(&mut self.0, f)
     }
 }

--- a/src/characteristic/generated/thread_control_point.rs
+++ b/src/characteristic/generated/thread_control_point.rs
@@ -27,13 +27,13 @@ use crate::{
 // TODO - re-check MaximumDataLength
 /// Thread Control Point characteristic.
 #[derive(Debug, Default, Serialize)]
-pub struct ThreadControlPointCharacteristic(Characteristic<Vec<u8>>);
+pub struct ThreadControlPointCharacteristic(Characteristic<crate::tlv::Tlv8>);
 
 impl ThreadControlPointCharacteristic {
     /// Creates a new Thread Control Point characteristic.
     pub fn new(id: u64, accessory_id: u64) -> Self {
         #[allow(unused_mut)]
-        let mut c = Self(Characteristic::<Vec<u8>> {
+        let mut c = Self(Characteristic::<crate::tlv::Tlv8> {
             id,
             accessory_id,
             hap_type: HapType::ThreadControlPoint,
@@ -155,18 +155,18 @@ impl HapCharacteristicSetup for ThreadControlPointCharacteristic {
     }
 }
 
-impl CharacteristicCallbacks<Vec<u8>> for ThreadControlPointCharacteristic {
-    fn on_read(&mut self, f: Option<impl OnReadFn<Vec<u8>>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
+impl CharacteristicCallbacks<crate::tlv::Tlv8> for ThreadControlPointCharacteristic {
+    fn on_read(&mut self, f: Option<impl OnReadFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
 
-    fn on_update(&mut self, f: Option<impl OnUpdateFn<Vec<u8>>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
+    fn on_update(&mut self, f: Option<impl OnUpdateFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
 }
 
-impl AsyncCharacteristicCallbacks<Vec<u8>> for ThreadControlPointCharacteristic {
-    fn on_read_async(&mut self, f: Option<impl OnReadFuture<Vec<u8>>>) {
+impl AsyncCharacteristicCallbacks<crate::tlv::Tlv8> for ThreadControlPointCharacteristic {
+    fn on_read_async(&mut self, f: Option<impl OnReadFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_read_async(&mut self.0, f)
     }
 
-    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<Vec<u8>>>) {
+    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_update_async(&mut self.0, f)
     }
 }

--- a/src/characteristic/generated/wake_configuration.rs
+++ b/src/characteristic/generated/wake_configuration.rs
@@ -27,13 +27,13 @@ use crate::{
 // TODO - re-check MaximumDataLength
 /// Wake Configuration characteristic.
 #[derive(Debug, Default, Serialize)]
-pub struct WakeConfigurationCharacteristic(Characteristic<Vec<u8>>);
+pub struct WakeConfigurationCharacteristic(Characteristic<crate::tlv::Tlv8>);
 
 impl WakeConfigurationCharacteristic {
     /// Creates a new Wake Configuration characteristic.
     pub fn new(id: u64, accessory_id: u64) -> Self {
         #[allow(unused_mut)]
-        let mut c = Self(Characteristic::<Vec<u8>> {
+        let mut c = Self(Characteristic::<crate::tlv::Tlv8> {
             id,
             accessory_id,
             hap_type: HapType::WakeConfiguration,
@@ -155,18 +155,18 @@ impl HapCharacteristicSetup for WakeConfigurationCharacteristic {
     }
 }
 
-impl CharacteristicCallbacks<Vec<u8>> for WakeConfigurationCharacteristic {
-    fn on_read(&mut self, f: Option<impl OnReadFn<Vec<u8>>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
+impl CharacteristicCallbacks<crate::tlv::Tlv8> for WakeConfigurationCharacteristic {
+    fn on_read(&mut self, f: Option<impl OnReadFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
 
-    fn on_update(&mut self, f: Option<impl OnUpdateFn<Vec<u8>>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
+    fn on_update(&mut self, f: Option<impl OnUpdateFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
 }
 
-impl AsyncCharacteristicCallbacks<Vec<u8>> for WakeConfigurationCharacteristic {
-    fn on_read_async(&mut self, f: Option<impl OnReadFuture<Vec<u8>>>) {
+impl AsyncCharacteristicCallbacks<crate::tlv::Tlv8> for WakeConfigurationCharacteristic {
+    fn on_read_async(&mut self, f: Option<impl OnReadFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_read_async(&mut self.0, f)
     }
 
-    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<Vec<u8>>>) {
+    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_update_async(&mut self.0, f)
     }
 }

--- a/src/characteristic/generated/wan_configuration_list.rs
+++ b/src/characteristic/generated/wan_configuration_list.rs
@@ -27,13 +27,13 @@ use crate::{
 // TODO - re-check MaximumDataLength
 /// WAN Configuration List characteristic.
 #[derive(Debug, Default, Serialize)]
-pub struct WanConfigurationListCharacteristic(Characteristic<Vec<u8>>);
+pub struct WanConfigurationListCharacteristic(Characteristic<crate::tlv::Tlv8>);
 
 impl WanConfigurationListCharacteristic {
     /// Creates a new WAN Configuration List characteristic.
     pub fn new(id: u64, accessory_id: u64) -> Self {
         #[allow(unused_mut)]
-        let mut c = Self(Characteristic::<Vec<u8>> {
+        let mut c = Self(Characteristic::<crate::tlv::Tlv8> {
             id,
             accessory_id,
             hap_type: HapType::WanConfigurationList,
@@ -156,18 +156,18 @@ impl HapCharacteristicSetup for WanConfigurationListCharacteristic {
     }
 }
 
-impl CharacteristicCallbacks<Vec<u8>> for WanConfigurationListCharacteristic {
-    fn on_read(&mut self, f: Option<impl OnReadFn<Vec<u8>>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
+impl CharacteristicCallbacks<crate::tlv::Tlv8> for WanConfigurationListCharacteristic {
+    fn on_read(&mut self, f: Option<impl OnReadFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
 
-    fn on_update(&mut self, f: Option<impl OnUpdateFn<Vec<u8>>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
+    fn on_update(&mut self, f: Option<impl OnUpdateFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
 }
 
-impl AsyncCharacteristicCallbacks<Vec<u8>> for WanConfigurationListCharacteristic {
-    fn on_read_async(&mut self, f: Option<impl OnReadFuture<Vec<u8>>>) {
+impl AsyncCharacteristicCallbacks<crate::tlv::Tlv8> for WanConfigurationListCharacteristic {
+    fn on_read_async(&mut self, f: Option<impl OnReadFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_read_async(&mut self.0, f)
     }
 
-    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<Vec<u8>>>) {
+    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_update_async(&mut self.0, f)
     }
 }

--- a/src/characteristic/generated/wan_status_list.rs
+++ b/src/characteristic/generated/wan_status_list.rs
@@ -27,13 +27,13 @@ use crate::{
 // TODO - re-check MaximumDataLength
 /// WAN Status List characteristic.
 #[derive(Debug, Default, Serialize)]
-pub struct WanStatusListCharacteristic(Characteristic<Vec<u8>>);
+pub struct WanStatusListCharacteristic(Characteristic<crate::tlv::Tlv8>);
 
 impl WanStatusListCharacteristic {
     /// Creates a new WAN Status List characteristic.
     pub fn new(id: u64, accessory_id: u64) -> Self {
         #[allow(unused_mut)]
-        let mut c = Self(Characteristic::<Vec<u8>> {
+        let mut c = Self(Characteristic::<crate::tlv::Tlv8> {
             id,
             accessory_id,
             hap_type: HapType::WanStatusList,
@@ -156,18 +156,18 @@ impl HapCharacteristicSetup for WanStatusListCharacteristic {
     }
 }
 
-impl CharacteristicCallbacks<Vec<u8>> for WanStatusListCharacteristic {
-    fn on_read(&mut self, f: Option<impl OnReadFn<Vec<u8>>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
+impl CharacteristicCallbacks<crate::tlv::Tlv8> for WanStatusListCharacteristic {
+    fn on_read(&mut self, f: Option<impl OnReadFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
 
-    fn on_update(&mut self, f: Option<impl OnUpdateFn<Vec<u8>>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
+    fn on_update(&mut self, f: Option<impl OnUpdateFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
 }
 
-impl AsyncCharacteristicCallbacks<Vec<u8>> for WanStatusListCharacteristic {
-    fn on_read_async(&mut self, f: Option<impl OnReadFuture<Vec<u8>>>) {
+impl AsyncCharacteristicCallbacks<crate::tlv::Tlv8> for WanStatusListCharacteristic {
+    fn on_read_async(&mut self, f: Option<impl OnReadFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_read_async(&mut self.0, f)
     }
 
-    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<Vec<u8>>>) {
+    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_update_async(&mut self.0, f)
     }
 }

--- a/src/characteristic/generated/wi_fi_configuration_control.rs
+++ b/src/characteristic/generated/wi_fi_configuration_control.rs
@@ -27,13 +27,13 @@ use crate::{
 // TODO - re-check MaximumDataLength
 /// Wi-Fi Configuration Control characteristic.
 #[derive(Debug, Default, Serialize)]
-pub struct WiFiConfigurationControlCharacteristic(Characteristic<Vec<u8>>);
+pub struct WiFiConfigurationControlCharacteristic(Characteristic<crate::tlv::Tlv8>);
 
 impl WiFiConfigurationControlCharacteristic {
     /// Creates a new Wi-Fi Configuration Control characteristic.
     pub fn new(id: u64, accessory_id: u64) -> Self {
         #[allow(unused_mut)]
-        let mut c = Self(Characteristic::<Vec<u8>> {
+        let mut c = Self(Characteristic::<crate::tlv::Tlv8> {
             id,
             accessory_id,
             hap_type: HapType::WiFiConfigurationControl,
@@ -159,18 +159,18 @@ impl HapCharacteristicSetup for WiFiConfigurationControlCharacteristic {
     }
 }
 
-impl CharacteristicCallbacks<Vec<u8>> for WiFiConfigurationControlCharacteristic {
-    fn on_read(&mut self, f: Option<impl OnReadFn<Vec<u8>>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
+impl CharacteristicCallbacks<crate::tlv::Tlv8> for WiFiConfigurationControlCharacteristic {
+    fn on_read(&mut self, f: Option<impl OnReadFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_read(&mut self.0, f) }
 
-    fn on_update(&mut self, f: Option<impl OnUpdateFn<Vec<u8>>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
+    fn on_update(&mut self, f: Option<impl OnUpdateFn<crate::tlv::Tlv8>>) { CharacteristicCallbacks::on_update(&mut self.0, f) }
 }
 
-impl AsyncCharacteristicCallbacks<Vec<u8>> for WiFiConfigurationControlCharacteristic {
-    fn on_read_async(&mut self, f: Option<impl OnReadFuture<Vec<u8>>>) {
+impl AsyncCharacteristicCallbacks<crate::tlv::Tlv8> for WiFiConfigurationControlCharacteristic {
+    fn on_read_async(&mut self, f: Option<impl OnReadFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_read_async(&mut self.0, f)
     }
 
-    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<Vec<u8>>>) {
+    fn on_update_async(&mut self, f: Option<impl OnUpdateFuture<crate::tlv::Tlv8>>) {
         AsyncCharacteristicCallbacks::on_update_async(&mut self.0, f)
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -72,7 +72,9 @@ pub struct Config {
 
 impl Config {
     /// Redetermines the `host` field to the IP of the system's first non-loopback network interface.
-    pub fn redetermine_local_ip(&mut self) { self.host = get_local_ip(); }
+    pub fn redetermine_local_ip(&mut self) {
+        self.host = get_local_ip();
+    }
 
     /// Derives mDNS TXT records from the `Config`.
     pub(crate) fn txt_records(&self) -> [String; 8] {
@@ -125,7 +127,7 @@ fn generate_ed25519_keypair() -> Ed25519Keypair {
 
 /// Returns the IP of the system's first non-loopback network interface or defaults to `127.0.0.1`.
 fn get_local_ip() -> IpAddr {
-    for iface in get_if_addrs::get_if_addrs().unwrap() {
+    for iface in if_addrs::get_if_addrs().unwrap() {
         if !iface.is_loopback() {
             return iface.ip();
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,7 @@ mod error;
 mod event;
 mod hap_type;
 mod pin;
-mod pointer;
+pub mod pointer;
 mod tlv;
 mod transport;
 


### PR DESCRIPTION
I needed this crate to setup some home automation and got tired of homebridge. Few things changed:

- ifaddr had to be updated
- basic tlv support had to be added
- i made pointer aliases public because they are used by public traits anyway - i didn't want to copy them
- basic camera support added

In case of ipcamera I have created trait which can be implemented for ffmpeg if needed.

I decided to use gstreamer bindings. It worked well with my hikvision ip camera. IMO the code is not perfect but better than nothing.

gstreamer18 support is needed to build it for raspberrypi (glib dependency).